### PR TITLE
introduce Ops.Gl.ShaderEffects.Bend

### DIFF
--- a/src/ops/base/Ops.Gl.ShaderEffects.Bend/Ops.Gl.ShaderEffects.Bend.js
+++ b/src/ops/base/Ops.Gl.ShaderEffects.Bend/Ops.Gl.ShaderEffects.Bend.js
@@ -1,0 +1,103 @@
+op.name='Bend';
+var render=op.inFunction('render');
+var rotX=op.inValue('RotX');
+var rotY=op.inValue('RotY');
+var rotZ=op.inValue('RotZ');
+var scale=op.inValue('Scale', 1);
+var offset=op.inValue('Offset');
+var amount=op.inValue('Amount');
+var limited=op.inValueBool('Limited', true);
+var next=op.addOutPort(new Port(op,"trigger",OP_PORT_TYPE_FUNCTION));
+
+var srcHeadVert=attachments.bend_vert;
+var srcBodyVert=''
+    .endl()+'   MOD_bendDistort(pos.xyz, norm);'
+    .endl();
+
+var uniAmount=null;
+var uniRange=null;
+var uniTransMatrix=null;
+var uniInvTransMatrix=null;
+var cgl=op.patch.cgl;
+var shader=null;
+var mod=null;
+
+var matricesValid = false;
+var transMatrix = mat4.create();
+var invTransMatrix = mat4.create();
+var amountRadians = 0;
+
+function invalidateMatrices() {
+    matricesValid = false;
+}
+
+rotX.onValueChange(invalidateMatrices);
+rotY.onValueChange(invalidateMatrices);
+rotZ.onValueChange(invalidateMatrices);
+scale.onValueChange(invalidateMatrices);
+offset.onValueChange(invalidateMatrices);
+
+amount.onValueChange(function() { amountRadians = amount.get()*CGL.DEG2RAD; });
+limited.onValueChange(function() {
+    uniRange.setValue(limited.get() ? [0, 1] : [-Infinity, Infinity]);
+});
+
+mat4.identity(transMatrix);
+mat4.identity(invTransMatrix);
+
+function updateMatrices() {
+    if (matricesValid) return;
+
+    var tvec = vec3.create();
+    vec3.set(tvec, offset.get(), 0, 0);
+
+    var svec = vec4.create();
+    var s = 1 / scale.get();
+    vec3.set(svec, s, s, s);
+
+    mat4.identity(transMatrix);
+    mat4.translate(transMatrix, transMatrix, tvec);
+
+    mat4.rotateX(transMatrix, transMatrix, rotX.get()*CGL.DEG2RAD);
+    mat4.rotateY(transMatrix, transMatrix, rotY.get()*CGL.DEG2RAD);
+    mat4.rotateZ(transMatrix, transMatrix, rotZ.get()*CGL.DEG2RAD);
+
+    mat4.scale(transMatrix, transMatrix, svec);
+
+    mat4.invert(invTransMatrix, transMatrix);
+    matricesValid = true;
+}
+
+function removeModule()
+{
+    if(shader && mod)
+    {
+        shader.removeModule(mod);
+        shader=null;
+    }
+}
+
+render.onLinkChanged=removeModule;
+render.onTriggered=function()
+{
+    if(cgl.getShader()!=shader)
+    {
+        if(shader) removeModule();
+        shader=cgl.getShader();
+        mod=shader.addModule(
+            {
+                name:'MODULE_VERTEX_POSITION',
+                srcHeadVert:attachments.test_vert,
+                srcBodyVert:srcBodyVert
+            });
+
+        uniAmount=new CGL.Uniform(shader,'f',mod.prefix+'amount',0);
+        uniRange=new CGL.Uniform(shader,'2f',mod.prefix+'range', [0, 1]);
+        uniTransMatrix=new CGL.Uniform(shader,'m4',mod.prefix+'transMatrix',transMatrix);
+        uniInvTransMatrix=new CGL.Uniform(shader,'m4',mod.prefix+'invTransMatrix',invTransMatrix);
+    }
+
+    updateMatrices();
+    uniAmount.setValue(amountRadians);
+    next.trigger();
+};

--- a/src/ops/base/Ops.Gl.ShaderEffects.Bend/att_bend.vert
+++ b/src/ops/base/Ops.Gl.ShaderEffects.Bend/att_bend.vert
@@ -1,0 +1,28 @@
+UNI float MOD_amount;
+UNI vec2 MOD_range;
+UNI mat4 MOD_transMatrix;
+UNI mat4 MOD_invTransMatrix;
+
+void MOD_bendDistort(inout vec3 pos, inout vec3 norm)
+{
+    pos = (MOD_transMatrix * vec4(pos, 1.0)).xyz;
+    norm = (vec4(norm, 0.0) * MOD_invTransMatrix).xyz;
+
+    float PI = 3.14159265;
+    if (abs(MOD_amount) > 1e-5) {
+        float bendAngle = MOD_amount;
+        float radius = 1.0 / bendAngle;
+
+        float d = clamp(pos.x, MOD_range.x, MOD_range.y);
+        float th = PI * 0.5 + (bendAngle * d);
+        float s = sin(th);
+        float c = cos(th);
+        pos.xy = vec2(s * (pos.x - d) - c * (radius + pos.y),
+                      c * (pos.x - d) + s * (radius + pos.y) - radius);
+        norm.xy = vec2(s * norm.x - c * norm.y,
+                       c * norm.x + s * norm.y);
+    }
+
+    pos = (MOD_invTransMatrix * vec4(pos, 1.0)).xyz;
+    norm = (vec4(norm, 0.0) * MOD_transMatrix).xyz;
+}


### PR DESCRIPTION
It's quite useful to be able to bend objects along an axis, for
instance for doing ad-hoc animations. So let's add a shader effect
for that.

This takes care to also update normals, so any normals passed through
should also be distorted appropriately.

@pandrr: This is untested as-is, as I haven't figured out how to test locally yet. That is, I've tested the code on cables.gl, but I haven't yet tested that packaging it up this way actually works. I just thought I'd send the code for review up front anyway. If that's not appropriate, I can re-send after testing.