### PR TITLE
customShaderOp added extra header text for easier use

### DIFF
--- a/src/core/cgl_shader.js
+++ b/src/core/cgl_shader.js
@@ -764,6 +764,13 @@ CGL.Shader.prototype.getDefaultFragmentShader = CGL.Shader.getDefaultFragmentSha
         b=0.5;
     }
     return ''
+        .endl()+'//allows you to pass a uniform value into this shader'
+        .endl()+'uniform float uValueIn;'
+        .endl()+'//Allows a texture lookup'
+        .endl()+'UNI sampler2d textureIn;'
+        .endl()+'//uv co-ordinates'
+        .endl()+'IN vec2 texCoord;'
+        .endl()+'//used to inject this code into another shader'
         .endl()+'{{MODULES_HEAD}}'
         .endl() + 'void main()'
         .endl() + '{'


### PR DESCRIPTION
Added comments and examples for creating uniforms, texture inputs anduv/texCoord. 
So that when the op is created a new user can instantly start with the basics