### PR TITLE
PointMaterial2 op - fix for massive values

### DIFF
--- a/src/ops/base/Ops.Gl.Shader.PointMaterial2/Ops.Gl.Shader.PointMaterial2.js
+++ b/src/ops/base/Ops.Gl.Shader.PointMaterial2/Ops.Gl.Shader.PointMaterial2.js
@@ -1,0 +1,145 @@
+const cgl=op.patch.cgl;
+
+const render=op.addInPort(new CABLES.Port(op,"render",CABLES.OP_PORT_TYPE_FUNCTION) );
+const trigger=op.outTrigger('trigger');
+const shaderOut=op.addOutPort(new CABLES.Port(op,"shader",CABLES.OP_PORT_TYPE_OBJECT));
+
+const pointSize=op.addInPort(new CABLES.Port(op,"PointSize",CABLES.OP_PORT_TYPE_VALUE));
+const randomSize=op.inValue("Random Size",3);
+
+const makeRound=op.addInPort(new CABLES.Port(op,"Round",CABLES.OP_PORT_TYPE_VALUE,{ display:'bool' }));
+const doScale=op.addInPort(new CABLES.Port(op,"Scale by Distance",CABLES.OP_PORT_TYPE_VALUE,{ display:'bool' }));
+var r=op.addInPort(new CABLES.Port(op,"r",CABLES.OP_PORT_TYPE_VALUE,{ display:'range',colorPick:'true' }));
+var g=op.addInPort(new CABLES.Port(op,"g",CABLES.OP_PORT_TYPE_VALUE,{ display:'range' }));
+var b=op.addInPort(new CABLES.Port(op,"b",CABLES.OP_PORT_TYPE_VALUE,{ display:'range' }));
+var a=op.addInPort(new CABLES.Port(op,"a",CABLES.OP_PORT_TYPE_VALUE,{ display:'range' }));
+var preMultipliedAlpha=op.addInPort(new CABLES.Port(op,"preMultiplied alpha",CABLES.OP_PORT_TYPE_VALUE,{ display:'bool' }));
+
+makeRound.set(true);
+doScale.set(false);
+pointSize.set(3);
+
+var shader=new CGL.Shader(cgl,'PointMaterial');
+shader.setModules(['MODULE_VERTEX_POSITION','MODULE_COLOR','MODULE_BEGIN_FRAG']);
+
+shader.define('MAKE_ROUND');
+
+var uniPointSize=new CGL.Uniform(shader,'f','pointSize',pointSize);
+var uniRandomSize=new CGL.Uniform(shader,'f','randomSize',randomSize);
+
+shaderOut.set(shader);
+shader.setSource(attachments.shader_vert,attachments.shader_frag);
+shader.glPrimitive=cgl.gl.POINTS;
+shader.bindTextures=bindTextures;
+shaderOut.ignoreValueSerialize=true;
+
+r.set(Math.random());
+g.set(Math.random());
+b.set(Math.random());
+a.set(1.0);
+
+r.uniform=new CGL.Uniform(shader,'f','r',r);
+g.uniform=new CGL.Uniform(shader,'f','g',g);
+b.uniform=new CGL.Uniform(shader,'f','b',b);
+a.uniform=new CGL.Uniform(shader,'f','a',a);
+
+var uniWidth=new CGL.Uniform(shader,'f','canvasWidth',cgl.canvasWidth);
+var uniHeight=new CGL.Uniform(shader,'f','canvasHeight',cgl.canvasHeight);
+
+render.onTriggered=doRender;
+
+var texture=op.inTexture("texture");
+var textureUniform=null;
+
+var textureMask=op.inTexture("Texture Mask");
+var textureMaskUniform=null;
+
+op.preRender=function()
+{
+    if(shader)shader.bind();
+    doRender();
+};
+
+function bindTextures()
+{
+    if(texture.get()) cgl.setTexture(0,texture.get().tex);
+    if(textureMask.get()) cgl.setTexture(1,textureMask.get().tex);
+}
+
+function doRender()
+{
+    uniWidth.setValue(cgl.canvasWidth);
+    uniHeight.setValue(cgl.canvasHeight);
+
+    cgl.setShader(shader);
+    bindTextures();
+    if(preMultipliedAlpha.get())cgl.gl.blendFunc(cgl.gl.ONE, cgl.gl.ONE_MINUS_SRC_ALPHA);
+
+    trigger.trigger();
+    if(preMultipliedAlpha.get())cgl.gl.blendFunc(cgl.gl.SRC_ALPHA,cgl.gl.ONE_MINUS_SRC_ALPHA);
+
+    cgl.setPreviousShader();
+}
+
+doScale.onChange=function()
+{
+    if(doScale.get()) shader.define('SCALE_BY_DISTANCE');
+        else shader.removeDefine('SCALE_BY_DISTANCE');
+};
+
+makeRound.onChange=function()
+{
+    if(makeRound.get()) shader.define('MAKE_ROUND');
+        else shader.removeDefine('MAKE_ROUND');
+};
+
+texture.onChange=function()
+{
+    if(texture.get())
+    {
+        if(textureUniform!==null)return;
+        shader.removeUniform('diffTex');
+        shader.define('HAS_TEXTURE_DIFFUSE');
+        textureUniform=new CGL.Uniform(shader,'t','diffTex',0);
+    }
+    else
+    {
+        shader.removeUniform('diffTex');
+        shader.removeDefine('HAS_TEXTURE_DIFFUSE');
+        textureUniform=null;
+    }
+};
+
+textureMask.onChange=function()
+{
+    if(textureMask.get())
+    {
+        if(textureMaskUniform!==null)return;
+        shader.removeUniform('texMask');
+        shader.define('HAS_TEXTURE_MASK');
+        textureMaskUniform=new CGL.Uniform(shader,'t','texMask',1);
+    }
+    else
+    {
+        shader.removeUniform('texMask');
+        shader.removeDefine('HAS_TEXTURE_MASK');
+        textureMaskUniform=null;
+    }
+};
+
+var colorizeTexture=op.addInPort(new CABLES.Port(op,"colorizeTexture",CABLES.OP_PORT_TYPE_VALUE,{ display:'bool' }));
+colorizeTexture.set(false);
+colorizeTexture.onChange=function()
+{
+    if(colorizeTexture.get()) shader.define('COLORIZE_TEXTURE');
+        else shader.removeDefine('COLORIZE_TEXTURE');
+};
+
+var textureLookup=op.addInPort(new CABLES.Port(op,"texture Lookup",CABLES.OP_PORT_TYPE_VALUE,{ display:'bool' }));
+textureLookup.set(false);
+textureLookup.onChange=function()
+{
+    if(textureLookup.get()) shader.define('LOOKUP_TEXTURE');
+        else shader.removeDefine('LOOKUP_TEXTURE');
+};
+

--- a/src/ops/base/Ops.Gl.Shader.PointMaterial2/att_shader.frag
+++ b/src/ops/base/Ops.Gl.Shader.PointMaterial2/att_shader.frag
@@ -1,0 +1,62 @@
+
+{{MODULES_HEAD}}
+
+IN vec2 texCoord;
+#ifdef HAS_TEXTURES
+
+   #ifdef HAS_TEXTURE_DIFFUSE
+       UNI sampler2D diffTex;
+   #endif
+   #ifdef HAS_TEXTURE_MASK
+       UNI sampler2D texMask;
+   #endif
+#endif
+UNI float r;
+UNI float g;
+UNI float b;
+UNI float a;
+
+
+
+void main()
+{
+    {{MODULE_BEGIN_FRAG}}
+
+    vec4 col=vec4(r,g,b,a);
+
+    #ifdef HAS_TEXTURES
+
+        #ifdef HAS_TEXTURE_MASK
+            float mask=texture(texMask,vec2(gl_PointCoord.x,(1.0-gl_PointCoord.y))).r;
+        #endif
+
+        #ifdef HAS_TEXTURE_DIFFUSE
+
+            #ifdef LOOKUP_TEXTURE
+                col=texture(diffTex,texCoord);
+            #endif
+            #ifndef LOOKUP_TEXTURE
+                col=texture(diffTex,vec2(gl_PointCoord.x,(1.0-gl_PointCoord.y)));
+            #endif
+
+            #ifdef COLORIZE_TEXTURE
+              col.r*=r;
+              col.g*=g;
+              col.b*=b;
+            #endif
+        #endif
+        col.a*=a;
+    #endif
+
+    {{MODULE_COLOR}}
+
+    #ifdef MAKE_ROUND
+        if ((gl_PointCoord.x-0.5)*(gl_PointCoord.x-0.5) + (gl_PointCoord.y-0.5)*(gl_PointCoord.y-0.5) > 0.25) discard; //col.a=0.0;
+    #endif
+
+    #ifdef HAS_TEXTURE_MASK
+        col.a=mask;
+    #endif
+
+    outColor = col;
+}

--- a/src/ops/base/Ops.Gl.Shader.PointMaterial2/att_shader.vert
+++ b/src/ops/base/Ops.Gl.Shader.PointMaterial2/att_shader.vert
@@ -1,0 +1,58 @@
+{{MODULES_HEAD}}
+IN vec3 vPosition;
+IN vec2 attrTexCoord;
+
+OUT vec3 norm;
+#ifdef HAS_TEXTURES
+    OUT vec2 texCoord;
+#endif
+
+UNI mat4 projMatrix;
+UNI mat4 modelMatrix;
+UNI mat4 viewMatrix;
+
+UNI float pointSize;
+UNI vec3 camPos;
+
+UNI float canvasWidth;
+UNI float canvasHeight;
+UNI float camDistMul;
+
+UNI float randomSize;
+
+IN float attrVertIndex;
+
+
+float rand(float n){return fract(sin(n) * 43758.5453123);}
+
+#define POINTMATERIAL
+
+void main()
+{
+    float psMul=sqrt(canvasWidth/canvasHeight);
+
+    #ifdef HAS_TEXTURES
+        texCoord=attrTexCoord;
+    #endif
+
+    mat4 mMatrix=modelMatrix;
+
+    vec4 pos = vec4( vPosition, 1. );
+
+    {{MODULE_VERTEX_POSITION}}
+
+    vec4 model=mMatrix * pos;
+
+    psMul+=rand(attrVertIndex)*randomSize;
+
+    #ifndef SCALE_BY_DISTANCE
+        gl_PointSize = pointSize * psMul;
+    #endif
+    #ifdef SCALE_BY_DISTANCE
+        float cameraDist = distance(model.xyz, camPos);
+        gl_PointSize = (pointSize / cameraDist) * psMul;
+    #endif
+
+    gl_Position = projMatrix * viewMatrix * model;
+
+}


### PR DESCRIPTION
The problem with massive values needed for point size with random size set
to 0.0 has been fixed.
Also removed unused code.
Example patch : https://dev.cables.gl/ui/#/project/OXMNYy