### PR TITLE
New op Array2

### DIFF
--- a/src/ops/base/Ops.Array.Array2/Ops.Array.Array2.js
+++ b/src/ops/base/Ops.Array.Array2/Ops.Array.Array2.js
@@ -1,0 +1,55 @@
+const modeSelect = op.inValueSelect("Mode select",['Number','1,2,3,4'],'Number'),
+    inLength=op.inValueInt("Array length",10),
+    inDefaultValue=op.inValueFloat("Default Value"),
+    outArr=op.outArray("Array");
+
+var arr=[];
+
+modeSelect.onChange = function()
+{
+    //used to grey out parameter
+    if( modeSelect.get() === 'Number')
+    {
+        inDefaultValue.setUiAttribs({greyout:false});
+    }
+    else if(modeSelect.get() === '1,2,3,4')
+    {
+        inDefaultValue.setUiAttribs({greyout:true});
+    }
+    reset();
+}
+
+inDefaultValue.onChange = inLength.onChange = function ()
+{
+    reset();
+}
+
+function reset()
+{
+    arr.length = 0;
+
+    var arrLength = inLength.get();
+    var valueForArray = inDefaultValue.get();
+    var i;
+
+    //mode 0 - fill all array values with one number
+    if( modeSelect.get() === 'Number')
+    {
+        for(i=0;i<arrLength;i++)
+        {
+            arr[i]=valueForArray;
+        }
+    }
+
+    //mode 1 Continuous number array - increments up to array length
+    else
+    {
+        for(i = 0;i < arrLength; i++)
+        {
+            arr[i] = i;
+        }
+    }
+    outArr.set(null);
+    outArr.set(arr);
+}
+reset();


### PR DESCRIPTION
Made to replace the old array op which fills an array with one value
and the ContinuousNumberArray op which filled an array with incrementing
values.
op has a dropdown box to select the mode.
When 0,1,2,3 mode is selected then the default value paramater is greyed
out.
By default it starts in `Number` mode so that it still replicates the old ops behaviour.
Example : https://cables.gl/ui/#/project/2cL8wH

If this op is merged then the old array and ContinuousNumberArray ops
should be deprecated ticket #791