### PR TITLE
New op GateTrigger

### DIFF
--- a/src/ops/base/Ops.Trigger.GateTrigger/Ops.Trigger.GateTrigger.js
+++ b/src/ops/base/Ops.Trigger.GateTrigger/Ops.Trigger.GateTrigger.js
@@ -1,5 +1,4 @@
 const passThrough = op.inValueBool('Pass Through',true),
-    triggerIn = op.inTrigger('Trigger to pass'),
     exe = op.inTrigger('Execute'),
     triggerOut = op.outTrigger('Trigger out');
 

--- a/src/ops/base/Ops.Trigger.GateTrigger/Ops.Trigger.GateTrigger.js
+++ b/src/ops/base/Ops.Trigger.GateTrigger/Ops.Trigger.GateTrigger.js
@@ -1,0 +1,10 @@
+const passThrough = op.inValueBool('Pass Through',true),
+    triggerIn = op.inTrigger('Trigger to pass'),
+    exe = op.inTrigger('Execute'),
+    triggerOut = op.outTrigger('Trigger out');
+
+exe.onTriggered = function()
+{
+    if(passThrough.get())
+        triggerOut.trigger();
+}


### PR DESCRIPTION
Only allows a trigger through when pass through is true
Please review the code and example. I'd rather that the gate
works without needing a trigger to execute but I don't think that's
possible.
Example patch : https://dev.cables.gl/ui/#/project/5ce694f34b998128468a3ba1