### PR TITLE
new version of barrel distortion - amount set to 0 results in no distortion

### DIFF
--- a/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.js
+++ b/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.js
@@ -1,0 +1,37 @@
+const
+    render=op.inTrigger('render'),
+    blendMode=CGL.TextureEffect.AddBlendSelect(op,"Blend Mode","normal"),
+    amount = op.inValueSlider("Amount",1.0),
+    intensity=op.inValue("Intensity",10.),
+    trigger=op.outTrigger('Trigger');
+
+const cgl=op.patch.cgl;
+const shader=new CGL.Shader(cgl);
+
+shader.setSource(shader.getDefaultVertexShader(),attachments.barreldistort_frag);
+
+const
+    textureUniform=new CGL.Uniform(shader,'t','tex',0),
+    uniintensity=new CGL.Uniform(shader,'f','intensity',0),
+    amountUniform = new CGL.Uniform(shader,'f','amount',amount);
+
+CGL.TextureEffect.setupBlending(op,shader,blendMode,amount);
+
+render.onTriggered=function()
+{
+    if(!CGL.TextureEffect.checkOpInEffect(op)) return;
+    var texture=cgl.currentTextureEffect.getCurrentSourceTexture();
+
+    uniintensity.setValue(intensity.get()*(1/texture.width));
+
+    cgl.setShader(shader);
+    cgl.currentTextureEffect.bind();
+
+    cgl.setTexture(0, texture.tex );
+    // cgl.gl.bindTexture(cgl.gl.TEXTURE_2D, texture.tex );
+
+    cgl.currentTextureEffect.finish();
+    cgl.setPreviousShader();
+
+    trigger.trigger();
+};

--- a/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.json
+++ b/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.json
@@ -3,7 +3,7 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "pandr",
             "date": 1579615567550
         }
     ],
@@ -39,6 +39,6 @@
         ],
         "name": "Ops.Gl.TextureEffects.BarrelDistortion_v2"
     },
-    "authorName": "cables",
+    "authorName": "pandr",
     "created": 1579615623326
 }

--- a/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.json
+++ b/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.json
@@ -1,0 +1,44 @@
+{
+    "id": "6ac723ad-5442-435a-b600-e18ba82ceff7",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1579615567550
+        }
+    ],
+    "layout": {
+        "portsIn": [
+            {
+                "type": "1",
+                "name": "render"
+            },
+            {
+                "type": "0",
+                "name": "Blend Mode",
+                "group": "Blending",
+                "subType": "string"
+            },
+            {
+                "type": "0",
+                "name": "Amount",
+                "group": "Blending",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Intensity",
+                "subType": "number"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "1",
+                "name": "Trigger"
+            }
+        ],
+        "name": "Ops.Gl.TextureEffects.BarrelDistortion_v2"
+    },
+    "authorName": "cables",
+    "created": 1579615623326
+}

--- a/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.json
+++ b/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/Ops.Gl.TextureEffects.BarrelDistortion_v2.json
@@ -3,7 +3,7 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "pandr",
+            "author": "pandur",
             "date": 1579615567550
         }
     ],
@@ -39,6 +39,6 @@
         ],
         "name": "Ops.Gl.TextureEffects.BarrelDistortion_v2"
     },
-    "authorName": "pandr",
+    "authorName": "pandur",
     "created": 1579615623326
 }

--- a/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/att_barreldistort.frag
+++ b/src/ops/base/Ops.Gl.TextureEffects.BarrelDistortion_v2/att_barreldistort.frag
@@ -1,0 +1,28 @@
+IN vec2 texCoord;
+UNI sampler2D tex;
+UNI float amount;
+UNI float intensity;
+
+{{CGL.BLENDMODES}}
+
+// adapted from https://www.shadertoy.com/view/MlSXR3
+
+vec2 brownConradyDistortion(vec2 uv)
+{
+// positive values of K1 give barrel distortion, negative give pincushion
+    float barrelDistortion1 = intensity*10.; // K1 in text books
+    float barrelDistortion2 = 0.; // K2 in text books
+    float r2 = uv.x*uv.x + uv.y*uv.y;
+    uv *= 1.0 + barrelDistortion1 * r2 + barrelDistortion2 * r2 * r2;
+
+    // tangential distortion (due to off center lens elements)
+    // is not modeled in this function, but if it was, the terms would go here
+    return uv;
+}
+
+void main()
+{
+   vec2 tc=brownConradyDistortion(texCoord-0.5)+0.5;
+   vec4 col=texture(tex,texCoord);
+   outColor=cgl_blend(col,texture(tex,tc),amount);
+}


### PR DESCRIPTION
The only way to get this to not distort at 0 was to remove a constant modifier in the shader code.
This changes the result slightly so this is a new version of the op which doesn't change any existing patches.
Intensity used to have to go to very high values to have a noticeable effect. This is now multiplied by 10 to avoid this being so severe.