### PR TITLE
Random array integer fix + code cleanup

### DIFF
--- a/src/ops/base/Ops.Array.RandomNumbersArray3_v2/Ops.Array.RandomNumbersArray3_v2.js
+++ b/src/ops/base/Ops.Array.RandomNumbersArray3_v2/Ops.Array.RandomNumbersArray3_v2.js
@@ -1,0 +1,73 @@
+const
+    numValues=op.inValueInt("numValues",100),
+    min=op.inValueFloat("Min",-1),
+    max=op.inValueFloat("Max",1),
+    seed=op.inValueFloat("random seed"),
+    closed=op.inValueBool("Last == First"),
+    inInteger=op.inValueBool("Integer",false),
+    values=op.outArray("values"),
+    outTotalPoints = op.outNumber("Total points"),
+    outArrayLength = op.outNumber("Array length");
+
+op.setPortGroup("Value Range",[min,max]);
+op.setPortGroup("",[seed,closed]);
+
+values.ignoreValueSerialize=true;
+
+closed.onChange=max.onChange=
+    min.onChange=
+    numValues.onChange=
+    seed.onChange=
+    values.onLinkChanged=
+    inInteger.onChange=init;
+
+var arr=[];
+init();
+
+function init()
+{
+    Math.randomSeed=seed.get();
+
+    var isInteger=inInteger.get();
+
+    var arrLength = arr.length=Math.floor(Math.abs(numValues.get()*3));
+
+    if(arrLength === 0)
+    {
+        values.set(null);
+        outTotalPoints.set(0);
+        outArrayLength.set(0);
+        return;
+    }
+
+    var minIn = min.get();
+    var maxIn = max.get();
+
+    for(var i=0;i<arrLength;i+=3)
+    {
+        if(!isInteger)
+        {
+            arr[i+0]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+            arr[i+1]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+            arr[i+2]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+        }
+        else
+        {
+            arr[i+0]=Math.floor(Math.seededRandom() * (( maxIn - minIn )+1) + minIn) ;
+            arr[i+1]=Math.floor(Math.seededRandom() * (( maxIn - minIn )+1) + minIn) ;
+            arr[i+2]=Math.floor(Math.seededRandom() * (( maxIn - minIn )+1) + minIn) ;
+        }
+    }
+
+    if(closed.get() && arrLength>3)
+    {
+        arr[arrLength-3+0]=arr[0];
+        arr[arrLength-3+1]=arr[1];
+        arr[arrLength-3+2]=arr[2];
+    }
+
+    values.set(null);
+    values.set(arr);
+    outTotalPoints.set(arrLength/3);
+    outArrayLength.set(arrLength);
+};

--- a/src/ops/base/Ops.Array.RandomNumbersArray3_v2/Ops.Array.RandomNumbersArray3_v2.json
+++ b/src/ops/base/Ops.Array.RandomNumbersArray3_v2/Ops.Array.RandomNumbersArray3_v2.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "pandur",
             "date": 1579773524553
         }
     ],
-    "authorName": "cables",
+    "authorName": "pandur",
     "created": 1579773541865,
     "layout": {
         "portsIn": [

--- a/src/ops/base/Ops.Array.RandomNumbersArray3_v2/Ops.Array.RandomNumbersArray3_v2.json
+++ b/src/ops/base/Ops.Array.RandomNumbersArray3_v2/Ops.Array.RandomNumbersArray3_v2.json
@@ -1,0 +1,65 @@
+{
+    "id": "45b2113a-1ca0-41d8-8d90-db3e394b669c",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1579773524553
+        }
+    ],
+    "authorName": "cables",
+    "created": 1579773541865,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "numValues",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Min",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Max",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "random seed",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Last == First",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Integer",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "3",
+                "name": "values"
+            },
+            {
+                "type": "0",
+                "name": "Total points",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Array length",
+                "subType": "number"
+            }
+        ],
+        "name": "Ops.Array.RandomNumbersArray3_v2"
+    }
+}

--- a/src/ops/base/Ops.Array.RandomNumbersArray4_v2/Ops.Array.RandomNumbersArray4_v2.js
+++ b/src/ops/base/Ops.Array.RandomNumbersArray4_v2/Ops.Array.RandomNumbersArray4_v2.js
@@ -1,0 +1,75 @@
+const
+    numValues=op.inValueInt("numValues",100),
+    min=op.inValueFloat("Min",0),
+    max=op.inValueFloat("Max",1),
+    seed=op.inValueFloat("random seed"),
+    closed=op.inValueBool("Last == First"),
+    inInteger=op.inValueBool("Integer",false),
+    values=op.outArray("values"),
+    outTotalPoints = op.outNumber("Tuple Amount"),
+    outArrayLength = op.outNumber("Array length");
+
+op.setPortGroup("Value Range",[min,max]);
+op.setPortGroup("",[seed,closed]);
+
+values.ignoreValueSerialize=true;
+
+closed.onChange=max.onChange=
+    min.onChange=
+    numValues.onChange=
+    seed.onChange=
+    values.onLinkChanged=
+    inInteger.onChange=init;
+
+var arr=[];
+init();
+
+function init()
+{
+    Math.randomSeed=seed.get();
+
+    var isInteger=inInteger.get();
+
+    var arrLength = arr.length=Math.floor(Math.abs(numValues.get()*4));
+    if(arrLength === 0)
+    {
+        values.set(null);
+        outTotalPoints.set(0);
+        outArrayLength.set(0);
+        return
+    }
+
+    var minIn = min.get();
+    var maxIn = max.get();
+
+    for(let i = 0; i < arrLength; i += 4)
+    {
+        if(!isInteger)
+        {
+            arr[i+0]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+            arr[i+1]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+            arr[i+2]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+            arr[i+3]=Math.seededRandom() * ( maxIn - minIn ) + minIn ;
+        }
+        else
+        {
+            arr[i+0]=Math.floor(Math.seededRandom() * ( (maxIn - minIn)+1 ) + minIn) ;
+            arr[i+1]=Math.floor(Math.seededRandom() * ( (maxIn - minIn)+1 ) + minIn) ;
+            arr[i+2]=Math.floor(Math.seededRandom() * ( (maxIn - minIn)+1 ) + minIn) ;
+            arr[i+3]=Math.floor(Math.seededRandom() * ( (maxIn - minIn)+1 ) + minIn) ;
+        }
+    }
+
+    if(closed.get() && arrLength>4)
+    {
+        arr[arrLength-4+0]=arr[0];
+        arr[arrLength-4+1]=arr[1];
+        arr[arrLength-4+2]=arr[2];
+        arr[arrLength-4+3]=arr[2];
+    }
+
+    values.set(null);
+    values.set(arr);
+    outTotalPoints.set(arrLength/4);
+    outArrayLength.set(arrLength);
+};

--- a/src/ops/base/Ops.Array.RandomNumbersArray4_v2/Ops.Array.RandomNumbersArray4_v2.json
+++ b/src/ops/base/Ops.Array.RandomNumbersArray4_v2/Ops.Array.RandomNumbersArray4_v2.json
@@ -1,0 +1,65 @@
+{
+    "id": "23c28491-06d3-4ea8-9e0d-c615b0783817",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1579773994512
+        }
+    ],
+    "authorName": "cables",
+    "created": 1579774018264,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "numValues",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Min",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Max",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "random seed",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Last == First",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Integer",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "3",
+                "name": "values"
+            },
+            {
+                "type": "0",
+                "name": "Tuple Amount",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Array length",
+                "subType": "number"
+            }
+        ],
+        "name": "Ops.Array.RandomNumbersArray4_v2"
+    }
+}

--- a/src/ops/base/Ops.Array.RandomNumbersArray4_v2/Ops.Array.RandomNumbersArray4_v2.json
+++ b/src/ops/base/Ops.Array.RandomNumbersArray4_v2/Ops.Array.RandomNumbersArray4_v2.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "pandur",
             "date": 1579773994512
         }
     ],
-    "authorName": "cables",
+    "authorName": "pandur",
     "created": 1579774018264,
     "layout": {
         "portsIn": [

--- a/src/ops/base/Ops.Array.RandomNumbersArray_v3/Ops.Array.RandomNumbersArray_v3.js
+++ b/src/ops/base/Ops.Array.RandomNumbersArray_v3/Ops.Array.RandomNumbersArray_v3.js
@@ -1,0 +1,58 @@
+const
+    numValues=op.inValueInt("numValues",10),
+    min=op.inValueFloat("Min",0),
+    max=op.inValueFloat("Max",1),
+    seed=op.inValueFloat("random seed"),
+    values=op.outArray("values",100),
+    outArrayLength = op.outNumber("Array length"),
+    inInteger=op.inValueBool("Integer",false);
+
+values.ignoreValueSerialize=true;
+op.setPortGroup("Value Range",[min,max]);
+op.setPortGroup("",[seed]);
+
+max.onChange=
+    min.onChange=
+    numValues.onChange=
+    seed.onChange=
+    values.onLinkChanged=
+    inInteger.onChange =init;
+
+var arr=[];
+init();
+
+function init()
+{
+    Math.randomSeed=seed.get();
+    var isInteger=inInteger.get();
+
+    var arrLength = arr.length=Math.abs(parseInt(numValues.get()));
+
+    var minIn = min.get();
+    var maxIn = max.get();
+
+    if(arrLength===0)
+    {
+        values.set(null);
+        outArrayLength.set(0);
+        return;
+    }
+    if(!isInteger)
+    {
+        for(var i=0;i<arrLength;i++)
+        {
+            arr[i]=Math.seededRandom()* ( maxIn - minIn ) + minIn ;
+        }
+    }
+    else
+    {
+        for(var i=0;i<arrLength;i++)
+        {
+            arr[i]=Math.floor(Math.seededRandom()* ( (maxIn - minIn) + 1 )) + minIn ;
+        }
+    }
+
+    values.set(null);
+    values.set(arr);
+    outArrayLength.set(arrLength);
+};

--- a/src/ops/base/Ops.Array.RandomNumbersArray_v3/Ops.Array.RandomNumbersArray_v3.json
+++ b/src/ops/base/Ops.Array.RandomNumbersArray_v3/Ops.Array.RandomNumbersArray_v3.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "pandur",
             "date": 1579773352826
         }
     ],
-    "authorName": "cables",
+    "authorName": "pandur",
     "created": 1579773372537,
     "layout": {
         "portsIn": [

--- a/src/ops/base/Ops.Array.RandomNumbersArray_v3/Ops.Array.RandomNumbersArray_v3.json
+++ b/src/ops/base/Ops.Array.RandomNumbersArray_v3/Ops.Array.RandomNumbersArray_v3.json
@@ -1,0 +1,55 @@
+{
+    "id": "e8609213-0803-4338-ab20-f95d0d65a110",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1579773352826
+        }
+    ],
+    "authorName": "cables",
+    "created": 1579773372537,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "numValues",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Min",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Max",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "random seed",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Integer",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "3",
+                "name": "values"
+            },
+            {
+                "type": "0",
+                "name": "Array length",
+                "subType": "number"
+            }
+        ],
+        "name": "Ops.Array.RandomNumbersArray_v3"
+    }
+}


### PR DESCRIPTION
Random number arrays never reached the max value when set to integer mode.
This has now been fixed in all the ops with this problem.
Removed large amount of get port calls.
All arrays now output null when array length is set to 0.
All ops now have a new version so that fixed seed numbers won't change anyone's existing patches.
fixes issue #1058