### PR TITLE
Fix for ops with random max value never reached with integer mode

### DIFF
--- a/src/ops/base/Ops.Math.RandomNumbers_v2/Ops.Math.RandomNumbers_v2.js
+++ b/src/ops/base/Ops.Math.RandomNumbers_v2/Ops.Math.RandomNumbers_v2.js
@@ -1,0 +1,71 @@
+const
+    index=op.inValueInt("index",0.0),
+    seed=op.inValueFloat("random seed"),
+    min=op.inValueFloat("Min",0),
+    max=op.inValueFloat("Max",1),
+    outX=op.outValue("X"),
+    outY=op.outValue("Y"),
+    outZ=op.outValue("Z"),
+    inInteger=op.inValueBool("Integer",false);
+
+var arr=[];
+var numValues=100;
+seed.set(Math.round(Math.random()*99999));
+
+op.setPortGroup("Value Range",[min,max]);
+
+index.onChange=update;
+
+init();
+
+op.init=inInteger.onChange=
+max.onChange=min.onChange=
+seed.onChange=inInteger.onChange=function()
+{
+    init();
+    update();
+}
+
+function update()
+{
+    var idx=Math.floor(index.get())||0;
+    if(idx*3>=arr.length)
+    {
+        numValues=idx+100;
+        init();
+    }
+
+    idx*=3;
+
+    outX.set(arr[idx+0]);
+    outY.set(arr[idx+1]);
+    outZ.set(arr[idx+2]);
+};
+
+function init()
+{
+    Math.randomSeed=seed.get();
+    var isInteger = inInteger.get();
+    var inMin = min.get();
+    var inMax = max.get();
+    arr.length=Math.floor(numValues*3) || 300;
+
+    if(!isInteger)
+    {
+        for(var i=0;i<arr.length;i+=3)
+        {
+            arr[i+0]=Math.seededRandom() * ( inMax - inMin ) + inMin ;
+            arr[i+1]=Math.seededRandom() * ( inMax - inMin ) + inMin ;
+            arr[i+2]=Math.seededRandom() * ( inMax - inMin ) + inMin ;
+        }
+    }
+    else
+    {
+        for(var i=0;i<arr.length;i+=3)
+        {
+            arr[i+0]=Math.floor(Math.seededRandom() * ((inMax - inMin )+1) + inMin) ;
+            arr[i+1]=Math.floor(Math.seededRandom() * ((inMax - inMin )+1) + inMin) ;
+            arr[i+2]=Math.floor(Math.seededRandom() * ((inMax - inMin )+1) + inMin) ;
+        }
+    }
+};

--- a/src/ops/base/Ops.Math.RandomNumbers_v2/Ops.Math.RandomNumbers_v2.json
+++ b/src/ops/base/Ops.Math.RandomNumbers_v2/Ops.Math.RandomNumbers_v2.json
@@ -1,0 +1,61 @@
+{
+    "id": "30979dbb-f4e7-4b1e-8e10-80c2ca4a3f88",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "pandur",
+            "date": 1579793461800
+        }
+    ],
+    "authorName": "pandur",
+    "created": 1579793476885,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "index",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "random seed",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Min",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Max",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Integer",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "0",
+                "name": "X",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Y",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Z",
+                "subType": "number"
+            }
+        ],
+        "name": "Ops.Math.RandomNumbers_v2"
+    }
+}

--- a/src/ops/base/Ops.Math.TriggerRandomNumber_v2/Ops.Math.TriggerRandomNumber_v2.js
+++ b/src/ops/base/Ops.Math.TriggerRandomNumber_v2/Ops.Math.TriggerRandomNumber_v2.js
@@ -1,0 +1,23 @@
+const
+    exe=op.inTriggerButton('Generate'),
+    min=op.inValue("min",0),
+    max=op.inValue("max",1),
+    outTrig = op.outTrigger("next"),
+    result=op.outValue("result"),
+    inInteger=op.inValueBool("Integer",false);
+
+exe.onTriggered=genRandom;
+max.onChange=genRandom;
+min.onChange=genRandom;
+inInteger.onChange=genRandom;
+
+op.setPortGroup("Value Range",[min,max]);
+genRandom();
+
+function genRandom()
+{
+    var r=(Math.random()*((max.get()-min.get()+1)))+min.get();
+    if(inInteger.get())r=Math.floor(r);
+    result.set(r);
+    outTrig.trigger();
+}

--- a/src/ops/base/Ops.Math.TriggerRandomNumber_v2/Ops.Math.TriggerRandomNumber_v2.json
+++ b/src/ops/base/Ops.Math.TriggerRandomNumber_v2/Ops.Math.TriggerRandomNumber_v2.json
@@ -1,0 +1,49 @@
+{
+    "id": "26f446cc-9107-4164-8209-5254487fa132",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "pandur",
+            "date": 1579793372912
+        }
+    ],
+    "authorName": "pandur",
+    "created": 1579793391418,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "1",
+                "name": "Generate"
+            },
+            {
+                "type": "0",
+                "name": "min",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "max",
+                "group": "Value Range",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Integer",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "1",
+                "name": "next"
+            },
+            {
+                "type": "0",
+                "name": "result",
+                "subType": "number"
+            }
+        ],
+        "name": "Ops.Math.TriggerRandomNumber_v2"
+    }
+}


### PR DESCRIPTION
New op versions of : 
```
Ops.Math.TriggerRandomNumber_v2
Ops.Math.RandomNumbers_v2
```
They now reach the max value when set to integer.