### PR TITLE
mouse_v2 op - smooth no longer returns mouse to center when mouse leaves canvas

### DIFF
--- a/src/ops/base/Ops.Devices.Mouse.Mouse_v2/Ops.Devices.Mouse.Mouse_v2.js
+++ b/src/ops/base/Ops.Devices.Mouse.Mouse_v2/Ops.Devices.Mouse.Mouse_v2.js
@@ -1,0 +1,269 @@
+const
+    active=op.inValueBool("Active",true),
+    relative=op.inValueBool("relative"),
+    normalize=op.inValueBool("normalize"),
+    flipY=op.inValueBool("flip y",true),
+    area=op.inValueSelect("Area",['Canvas','Document','Parent Element'],"Canvas"),
+    rightClickPrevDef=op.inBool("right click prevent default",true),
+    smooth=op.inValueBool("smooth"),
+    smoothSpeed=op.inValueFloat("smoothSpeed",20),
+    multiply=op.inValueFloat("multiply",1),
+    outMouseX=op.outValue("x"),
+    outMouseY=op.outValue("y"),
+    mouseDown=op.outValueBool("button down"),
+    mouseClick=op.outTrigger("click"),
+    mouseUp=op.outTrigger("Button Up"),
+    mouseClickRight=op.outTrigger("click right"),
+    mouseOver=op.outValueBool("mouseOver"),
+    outButton=op.outValue("button");
+
+op.setPortGroup('Behavior',[relative,normalize,flipY,area,rightClickPrevDef]);
+op.setPortGroup('Smoothing',[smooth,smoothSpeed,multiply]);
+
+var smoothTimer=0;
+var cgl=op.patch.cgl;
+var listenerElement=null;
+
+function setValue(x,y)
+{
+    if(normalize.get())
+    {
+        var w=cgl.canvas.width/cgl.pixelDensity;
+        var h=cgl.canvas.height/cgl.pixelDensity;
+        if(listenerElement==document.body)
+        {
+            w=listenerElement.clientWidth/cgl.pixelDensity;
+            h=listenerElement.clientHeight/cgl.pixelDensity;
+        }
+        outMouseX.set( (x/w*2.0-1.0)*multiply.get() );
+        outMouseY.set( (y/h*2.0-1.0)*multiply.get() );
+    }
+    else
+    {
+        outMouseX.set( x*multiply.get() );
+        outMouseY.set( y*multiply.get() );
+    }
+}
+
+smooth.onChange=function()
+{
+    if(smooth.get()) smoothTimer = setInterval(updateSmooth, 5);
+        else if(smoothTimer)clearTimeout(smoothTimer);
+};
+
+var smoothX,smoothY;
+var lineX=0,lineY=0;
+
+normalize.onChange=function()
+{
+    mouseX=0;
+    mouseY=0;
+    setValue(mouseX,mouseY);
+};
+
+var mouseX=cgl.canvas.width/2;
+var mouseY=cgl.canvas.height/2;
+
+lineX=mouseX;
+lineY=mouseY;
+
+outMouseX.set(mouseX);
+outMouseY.set(mouseY);
+
+var relLastX=0;
+var relLastY=0;
+var offsetX=0;
+var offsetY=0;
+addListeners();
+
+area.onChange=addListeners;
+
+var speed=0;
+
+function updateSmooth()
+{
+    speed=smoothSpeed.get();
+    if(speed<=0)speed=0.01;
+    var distanceX = Math.abs(mouseX - lineX);
+    var speedX = Math.round( distanceX / speed, 0 );
+    lineX = (lineX < mouseX) ? lineX + speedX : lineX - speedX;
+
+    var distanceY = Math.abs(mouseY - lineY);
+    var speedY = Math.round( distanceY / speed, 0 );
+    lineY = (lineY < mouseY) ? lineY + speedY : lineY - speedY;
+
+    setValue(lineX,lineY);
+}
+
+function onMouseEnter(e)
+{
+    mouseDown.set(false);
+    mouseOver.set(true);
+    speed=smoothSpeed.get();
+}
+
+function onMouseDown(e)
+{
+    outButton.set(e.which);
+    mouseDown.set(true);
+}
+
+function onMouseUp(e)
+{
+    outButton.set(0);
+    mouseDown.set(false);
+    mouseUp.trigger();
+}
+
+function onClickRight(e)
+{
+    mouseClickRight.trigger();
+    if(rightClickPrevDef.get()) e.preventDefault();
+}
+
+function onmouseclick(e)
+{
+    mouseClick.trigger();
+}
+
+
+function onMouseLeave(e)
+{
+    relLastX=0;
+    relLastY=0;
+
+    speed=100;
+
+    //disabled for now as it makes no sense that the mouse bounces back to the center
+    // if(area.get()!='Document')
+    // {
+    //     // leave anim
+    //     if(smooth.get())
+    //     {
+    //         mouseX=cgl.canvas.width/2;
+    //         mouseY=cgl.canvas.height/2;
+    //     }
+
+    // }
+    mouseOver.set(false);
+    mouseDown.set(false);
+}
+
+relative.onChange=function()
+{
+    offsetX=0;
+    offsetY=0;
+}
+
+function onmousemove(e)
+{
+    mouseOver.set(true);
+
+    if(!relative.get())
+    {
+        if(area.get()!="Document")
+        {
+            offsetX=e.offsetX;
+            offsetY=e.offsetY;
+        }
+        else
+        {
+            offsetX=e.clientX;
+            offsetY=e.clientY;
+        }
+
+        if(smooth.get())
+        {
+            mouseX=offsetX;
+
+            if(flipY.get()) mouseY=listenerElement.clientHeight-offsetY;
+                else mouseY=offsetY;
+        }
+        else
+        {
+            if(flipY.get()) setValue(offsetX,listenerElement.clientHeight-offsetY);
+                else setValue(offsetX,offsetY);
+        }
+    }
+    else
+    {
+        if(relLastX!=0 && relLastY!=0)
+        {
+            offsetX=e.offsetX-relLastX;
+            offsetY=e.offsetY-relLastY;
+        }
+        else
+        {
+
+        }
+
+        relLastX=e.offsetX;
+        relLastY=e.offsetY;
+
+        mouseX+=offsetX;
+        mouseY+=offsetY;
+
+        if(mouseY>460)mouseY=460;
+    }
+};
+
+function ontouchstart(event)
+{
+    mouseDown.set(true);
+
+    if(event.touches && event.touches.length>0) onMouseDown(event.touches[0]);
+}
+
+function ontouchend(event)
+{
+    mouseDown.set(false);
+    onMouseUp();
+}
+
+function removeListeners()
+{
+    listenerElement.removeEventListener('touchend', ontouchend);
+    listenerElement.removeEventListener('touchstart', ontouchstart);
+
+    listenerElement.removeEventListener('click', onmouseclick);
+    listenerElement.removeEventListener('mousemove', onmousemove);
+    listenerElement.removeEventListener('mouseleave', onMouseLeave);
+    listenerElement.removeEventListener('mousedown', onMouseDown);
+    listenerElement.removeEventListener('mouseup', onMouseUp);
+    listenerElement.removeEventListener('mouseenter', onMouseEnter);
+    listenerElement.removeEventListener('contextmenu', onClickRight);
+    listenerElement=null;
+}
+
+function addListeners()
+{
+    if(listenerElement)removeListeners();
+
+    listenerElement=cgl.canvas;
+    if(area.get()=='Document') listenerElement=document.body;
+    if(area.get()=='Parent Element') listenerElement=cgl.canvas.parentElement;
+
+    listenerElement.addEventListener('touchend', ontouchend);
+    listenerElement.addEventListener('touchstart', ontouchstart);
+
+    listenerElement.addEventListener('click', onmouseclick);
+    listenerElement.addEventListener('mousemove', onmousemove);
+    listenerElement.addEventListener('mouseleave', onMouseLeave);
+    listenerElement.addEventListener('mousedown', onMouseDown);
+    listenerElement.addEventListener('mouseup', onMouseUp);
+    listenerElement.addEventListener('mouseenter', onMouseEnter);
+    listenerElement.addEventListener('contextmenu', onClickRight);
+}
+
+active.onChange=function()
+{
+    if(listenerElement)removeListeners();
+    if(active.get())addListeners();
+}
+
+op.onDelete=function()
+{
+    removeListeners();
+};
+
+addListeners();

--- a/src/ops/base/Ops.Devices.Mouse.Mouse_v2/Ops.Devices.Mouse.Mouse_v2.json
+++ b/src/ops/base/Ops.Devices.Mouse.Mouse_v2/Ops.Devices.Mouse.Mouse_v2.json
@@ -1,0 +1,114 @@
+{
+    "id": "9fa3fc46-3147-4e3a-8ee8-a93ea9e8786e",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "pandur",
+            "date": 1582115532282
+        }
+    ],
+    "authorName": "pandur",
+    "created": 1582115559965,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "Active",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "relative",
+                "group": "Behavior",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "normalize",
+                "group": "Behavior",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "flip y",
+                "group": "Behavior",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Area index",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Area",
+                "group": "Behavior",
+                "subType": "string"
+            },
+            {
+                "type": "0",
+                "name": "right click prevent default",
+                "group": "Behavior",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "smooth",
+                "group": "Smoothing",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "smoothSpeed",
+                "group": "Smoothing",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "multiply",
+                "group": "Smoothing",
+                "subType": "number"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "0",
+                "name": "x",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "y",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "button down",
+                "subType": "boolean"
+            },
+            {
+                "type": "1",
+                "name": "click"
+            },
+            {
+                "type": "1",
+                "name": "Button Up"
+            },
+            {
+                "type": "1",
+                "name": "click right"
+            },
+            {
+                "type": "0",
+                "name": "mouseOver",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "button",
+                "subType": "number"
+            }
+        ],
+        "name": "Ops.Devices.Mouse.Mouse_v2"
+    }
+}


### PR DESCRIPTION
After reading [this post](https://forum.cables.gl/t/mouse-op-default-x-and-y-values/796/2) on the forum and trying it out I agreed that this shouldn't be default behavior if  `smooth` is on.
Ordered ports as well.