### PR TITLE
4 new Route ops #807

### DIFF
--- a/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.js
+++ b/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.js
@@ -1,0 +1,54 @@
+
+const
+    NUM_PORTS = 10,
+    DEFAULT_ARRAY_DEFAULT = [],
+    indexPort = op.inInt('index'),
+    arrayPort = op.inArray('array in'),
+    defaultArrayPort = op.inArray('default array', DEFAULT_ARRAY_DEFAULT),
+    arrayPorts = createOutPorts(DEFAULT_ARRAY_DEFAULT);
+
+// change listeners
+indexPort.onChange = arrayPort.onChange = defaultArrayPort.onChange = update;
+//defaultArrayPort.onChange = setDefaultValues;
+
+setDefaultValues();
+update();
+
+function createOutPorts()
+{
+    var arr = [];
+    for(var i=0; i<NUM_PORTS; i++)
+    {
+        var port = op.outArray('Index ' + i + ' array');
+        arr.push(port);
+    }
+    defaultArrayPort.set(null);
+    return arr;
+};
+
+function setDefaultValues()
+{
+    var defaultValue = defaultArrayPort.get();
+
+    arrayPorts.forEach(port => port.set(null));
+    if(defaultArrayPort.get())
+    {
+        arrayPorts.forEach(port => port.set(defaultValue));
+    }
+};
+
+function update()
+{
+    setDefaultValues();
+    var index = indexPort.get();
+    var value = arrayPort.get();
+
+    index = Math.floor(index);
+    index = clamp(index, 0, NUM_PORTS-1);
+    arrayPorts[index].set(value);
+};
+
+function clamp(value, min, max)
+{
+  return Math.min(Math.max(value, min), max);
+};

--- a/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.js
+++ b/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.js
@@ -7,9 +7,7 @@ const
     defaultArrayPort = op.inArray('default array', DEFAULT_ARRAY_DEFAULT),
     arrayPorts = createOutPorts(DEFAULT_ARRAY_DEFAULT);
 
-// change listeners
 indexPort.onChange = arrayPort.onChange = defaultArrayPort.onChange = update;
-//defaultArrayPort.onChange = setDefaultValues;
 
 setDefaultValues();
 update();

--- a/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.json
+++ b/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "andro",
             "date": 1587983870435
         }
     ],
-    "authorName": "cables",
+    "authorName": "andro",
     "created": 1587983880963,
     "layout": {
         "portsIn": [

--- a/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.json
+++ b/src/ops/base/Ops.Array.RouteArray/Ops.Array.RouteArray.json
@@ -1,0 +1,72 @@
+{
+    "id": "6597c011-7b2a-4d7c-93f5-40fcc2047cfe",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1587983870435
+        }
+    ],
+    "authorName": "cables",
+    "created": 1587983880963,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "index",
+                "subType": "integer"
+            },
+            {
+                "type": "3",
+                "name": "array in"
+            },
+            {
+                "type": "3",
+                "name": "default array"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "3",
+                "name": "Index 0 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 1 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 2 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 3 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 4 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 5 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 6 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 7 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 8 array"
+            },
+            {
+                "type": "3",
+                "name": "Index 9 array"
+            }
+        ],
+        "name": "Ops.Array.RouteArray"
+    }
+}

--- a/src/ops/base/Ops.Boolean.RouteBoolean/Ops.Boolean.RouteBoolean.js
+++ b/src/ops/base/Ops.Boolean.RouteBoolean/Ops.Boolean.RouteBoolean.js
@@ -1,11 +1,11 @@
 const
     NUM_PORTS = 10,
     indexPort = op.inInt('Index'),
-    valuePort = op.inString('String in',"cables"),
-    defaultStringPort = op.inString('Default string', ""),
+    valuePort = op.inBool('Boolean in',true),
+    defaultBoolPort = op.inBool('Default boolean', false),
     valuePorts = createOutPorts();
 
-indexPort.onChange = valuePort.onChange = defaultStringPort.onChange = update;
+indexPort.onChange = valuePort.onChange = defaultBoolPort.onChange = update;
 
 setDefaultValues();
 update();
@@ -15,7 +15,7 @@ function createOutPorts()
     var arr = [];
     for(var i=0; i<NUM_PORTS; i++)
     {
-        var port = op.outString('Index ' + i + ' string');
+        var port = op.outBool('Index ' + i + ' boolean');
         arr.push(port);
     }
     return arr;
@@ -23,11 +23,8 @@ function createOutPorts()
 
 function setDefaultValues()
 {
-    var defaultValue = defaultStringPort.get();
-    if(!defaultStringPort.get())
-    {
-        defaultValue = "";
-    }
+
+    var defaultValue = defaultBoolPort.get();
     valuePorts.forEach(port => port.set(defaultValue));
 };
 

--- a/src/ops/base/Ops.Boolean.RouteBoolean/Ops.Boolean.RouteBoolean.json
+++ b/src/ops/base/Ops.Boolean.RouteBoolean/Ops.Boolean.RouteBoolean.json
@@ -1,0 +1,84 @@
+{
+    "id": "88b3f5ec-0e45-4651-89ca-33173d001ab6",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1587993780448
+        }
+    ],
+    "authorName": "cables",
+    "created": 1587993796311,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "Index",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Boolean in",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Default boolean",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "0",
+                "name": "Index 0 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 1 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 2 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 3 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 4 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 5 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 6 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 7 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 8 boolean",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Index 9 boolean",
+                "subType": "boolean"
+            }
+        ],
+        "name": "Ops.Boolean.RouteBoolean"
+    }
+}

--- a/src/ops/base/Ops.Boolean.RouteBoolean/Ops.Boolean.RouteBoolean.json
+++ b/src/ops/base/Ops.Boolean.RouteBoolean/Ops.Boolean.RouteBoolean.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "andro",
             "date": 1587993780448
         }
     ],
-    "authorName": "cables",
+    "authorName": "andro",
     "created": 1587993796311,
     "layout": {
         "portsIn": [

--- a/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.js
+++ b/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.js
@@ -1,0 +1,54 @@
+
+const
+    NUM_PORTS = 10,
+    DEFAULT_OBJECT = {},
+    indexPort = op.inInt('index'),
+    objectPort = op.inObject('Object in'),
+    defaultObjectPort = op.inObject('default object', DEFAULT_OBJECT),
+    objectPorts = createOutPorts(DEFAULT_OBJECT);
+
+// change listeners
+indexPort.onChange = objectPort.onChange = defaultObjectPort.onChange = update;
+//defaultobjectPort.onChange = setDefaultValues;
+
+setDefaultValues();
+update();
+
+function createOutPorts()
+{
+    var arrayObjects = [];
+    for(var i=0; i<NUM_PORTS; i++)
+    {
+        var port = op.outObject('Index ' + i + ' Object');
+        arrayObjects.push(port);
+    }
+    defaultObjectPort.set(null);
+    return arrayObjects;
+};
+
+function setDefaultValues()
+{
+    var defaultValue = defaultObjectPort.get();
+
+    objectPorts.forEach(port => port.set(null));
+    if(defaultObjectPort.get())
+    {
+        objectPorts.forEach(port => port.set(defaultValue));
+    }
+};
+
+function update()
+{
+    setDefaultValues();
+    var index = indexPort.get();
+    var value = objectPort.get();
+
+    index = Math.floor(index);
+    index = clamp(index, 0, NUM_PORTS-1);
+    objectPorts[index].set(value);
+};
+
+function clamp(value, min, max)
+{
+  return Math.min(Math.max(value, min), max);
+};

--- a/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.js
+++ b/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.js
@@ -7,9 +7,7 @@ const
     defaultObjectPort = op.inObject('default object', DEFAULT_OBJECT),
     objectPorts = createOutPorts(DEFAULT_OBJECT);
 
-// change listeners
 indexPort.onChange = objectPort.onChange = defaultObjectPort.onChange = update;
-//defaultobjectPort.onChange = setDefaultValues;
 
 setDefaultValues();
 update();

--- a/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.json
+++ b/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.json
@@ -1,0 +1,72 @@
+{
+    "id": "bc969951-32b5-4226-9944-80a719a65497",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1587983950443
+        }
+    ],
+    "authorName": "cables",
+    "created": 1587986662115,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "index",
+                "subType": "integer"
+            },
+            {
+                "type": "2",
+                "name": "Object in"
+            },
+            {
+                "type": "2",
+                "name": "default object"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "2",
+                "name": "Index 0 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 1 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 2 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 3 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 4 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 5 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 6 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 7 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 8 Object"
+            },
+            {
+                "type": "2",
+                "name": "Index 9 Object"
+            }
+        ],
+        "name": "Ops.Json.RouteObject"
+    }
+}

--- a/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.json
+++ b/src/ops/base/Ops.Json.RouteObject/Ops.Json.RouteObject.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "andro",
             "date": 1587983950443
         }
     ],
-    "authorName": "cables",
+    "authorName": "andro",
     "created": 1587986662115,
     "layout": {
         "portsIn": [

--- a/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.js
+++ b/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.js
@@ -1,0 +1,56 @@
+// constants
+var NUM_PORTS = 10;
+var DEFAULT_STRING_DEFAULT = "";
+
+// input
+var indexPort = op.inInt('index');
+var valuePort = op.inString('string in',"cables");
+var defaultStringPort = op.inString('default string', "");
+
+// output
+var valuePorts = createOutPorts();
+
+// change listeners
+indexPort.onChange = valuePort.onChange = defaultStringPort.onChange = update;
+//defaultStringPort.onChange = setDefaultValues;
+
+setDefaultValues();
+update();
+// functions
+
+function createOutPorts()
+{
+    var arr = [];
+    for(var i=0; i<NUM_PORTS; i++)
+    {
+        var port = op.outString('Index ' + i + ' string');
+        arr.push(port);
+    }
+    return arr;
+};
+
+function setDefaultValues()
+{
+
+    var defaultValue = defaultStringPort.get();
+    // if(indexPort.get())
+    // {
+        valuePorts.forEach(port => port.set(defaultValue));
+    //}
+
+};
+
+function update()
+{
+    setDefaultValues();
+    var index = indexPort.get();
+    var value = valuePort.get();
+    index = Math.round(index);
+    index = clamp(index, 0, NUM_PORTS-1);
+    valuePorts[index].set(value);
+};
+
+function clamp(value, min, max)
+{
+  return Math.min(Math.max(value, min), max);
+};

--- a/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.json
+++ b/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.json
@@ -1,0 +1,72 @@
+{
+    "id": "9998ff83-335b-40cd-aa0e-4cae558cb551",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1587983335384
+        }
+    ],
+    "authorName": "cables",
+    "created": 1587983344507,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "index",
+                "subType": "integer"
+            },
+            {
+                "type": "5",
+                "name": "string in"
+            },
+            {
+                "type": "5",
+                "name": "default string"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "5",
+                "name": "Index 0 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 1 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 2 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 3 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 4 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 5 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 6 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 7 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 8 string"
+            },
+            {
+                "type": "5",
+                "name": "Index 9 string"
+            }
+        ],
+        "name": "Ops.String.RouteString"
+    }
+}

--- a/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.json
+++ b/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.json
@@ -13,16 +13,16 @@
         "portsIn": [
             {
                 "type": "0",
-                "name": "index",
+                "name": "Index",
                 "subType": "integer"
             },
             {
                 "type": "5",
-                "name": "string in"
+                "name": "String in"
             },
             {
                 "type": "5",
-                "name": "default string"
+                "name": "Default string"
             }
         ],
         "portsOut": [

--- a/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.json
+++ b/src/ops/base/Ops.String.RouteString/Ops.String.RouteString.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "andro",
             "date": 1587983335384
         }
     ],
-    "authorName": "cables",
+    "authorName": "andro",
     "created": 1587983344507,
     "layout": {
         "portsIn": [


### PR DESCRIPTION
From issue #807
4 new route ops
`RouteString` - If no default string is plugged in default string is `""`
`RouteBoolean` - If no default Boolean is plugged in default is `false`
`RouteArray` - If no default Array is plugged in default is `null` 
`RouteObject` - In no default object is plugged in default is `null`

Maybe it'd be an idea with the routeObject op to have an checkbox `default empty objects` so that if nothing is plugged into default object that the default is an empty object `{}` 


