### PR TITLE
new op CssPropertyString - #1470

### DIFF
--- a/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.js
+++ b/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.js
@@ -1,7 +1,7 @@
 const
     inEle = op.inObject("Element"),
     inProperty = op.inString("Property"),
-    inValue = op.inString("Values"),
+    inValue = op.inString("Value"),
     outEle = op.outObject("HTML Element");
 
 op.setPortGroup("Element", [inEle]);

--- a/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.js
+++ b/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.js
@@ -1,0 +1,46 @@
+const
+    inEle = op.inObject("Element"),
+    inProperty = op.inString("Property"),
+    inValue = op.inString("Values"),
+    outEle = op.outObject("HTML Element");
+
+op.setPortGroup("Element", [inEle]);
+op.setPortGroup("Attributes", [inProperty, inValue]);
+
+inProperty.onChange = updateProperty;
+inValue.onChange = update;
+let ele = null;
+
+inEle.onChange = inEle.onLinkChanged = function ()
+{
+    if (ele && ele.style)
+    {
+        ele.style[inProperty.get()] = "initial";
+    }
+    update();
+};
+
+function updateProperty()
+{
+    update();
+    op.setUiAttrib({ "extendTitle": inProperty.get() + "" });
+}
+
+function update()
+{
+    ele = inEle.get();
+    if (ele && ele.style)
+    {
+        const str = inValue.get();
+        try
+        {
+            ele.style[inProperty.get()] = str;
+        }
+        catch (e)
+        {
+            console.log(e);
+        }
+    }
+
+    outEle.set(inEle.get());
+}

--- a/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.json
+++ b/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.json
@@ -1,0 +1,38 @@
+{
+    "id": "a7abdfb9-4c2a-4ddb-8fc6-55b3fdfbdaf3",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "cables",
+            "date": 1594657868344
+        }
+    ],
+    "authorName": "cables",
+    "created": 1594657882461,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "2",
+                "name": "Element",
+                "group": "Element"
+            },
+            {
+                "type": "5",
+                "name": "Property",
+                "group": "Attributes"
+            },
+            {
+                "type": "5",
+                "name": "Values",
+                "group": "Attributes"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "2",
+                "name": "HTML Element"
+            }
+        ],
+        "name": "Ops.Html.CSSPropertyString"
+    }
+}

--- a/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.json
+++ b/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.json
@@ -23,7 +23,7 @@
             },
             {
                 "type": "5",
-                "name": "Values",
+                "name": "Value",
                 "group": "Attributes"
             }
         ],

--- a/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.json
+++ b/src/ops/base/Ops.Html.CSSPropertyString/Ops.Html.CSSPropertyString.json
@@ -3,11 +3,11 @@
     "changelog": [
         {
             "message": "created op",
-            "author": "cables",
+            "author": "andro",
             "date": 1594657868344
         }
     ],
-    "authorName": "cables",
+    "authorName": "andro",
     "created": 1594657882461,
     "layout": {
         "portsIn": [


### PR DESCRIPTION
Tested with strings like 
`padding : 10px 20px 30px 40px`
`border: solid red 10px`
removed the value suffix port as it's not necessary anymore. 