### PR TITLE
fix for output not being set on trigger with setStringOnTrigger

### DIFF
--- a/src/ops/base/Ops.Trigger.TriggerString/Ops.Trigger.TriggerString.js
+++ b/src/ops/base/Ops.Trigger.TriggerString/Ops.Trigger.TriggerString.js
@@ -1,14 +1,12 @@
 const
-    exec=op.inTriggerButton("Trigger"),
-    inString=op.inString("String",""),
-    next=op.outTrigger("Next"),
-    outString=op.outString("Result");
+    exec = op.inTriggerButton("Trigger"),
+    inString = op.inString("String", ""),
+    next = op.outTrigger("Next"),
+    outString = op.outString("Result");
 
-
-exec.onTriggered=function()
+outString.changeAlways = true;
+exec.onTriggered = function ()
 {
     outString.set(inString.get());
     next.trigger();
-
 };
-


### PR DESCRIPTION
Would fix issue #1580
Added
`outString.changeAlways = true;`
so it behaves like set number on trigger, otherwise string is only output once as string hasn't changed.