### PR TITLE
fix for math expression op working when created with default equation

### DIFF
--- a/src/ops/base/Ops.Math.MathExpression/Ops.Math.MathExpression.js
+++ b/src/ops/base/Ops.Math.MathExpression/Ops.Math.MathExpression.js
@@ -45,3 +45,4 @@ const evaluateFunction = () =>
 
 inA.onChange = inB.onChange = inC.onChange = inD.onChange = evaluateFunction;
 inEquation.onChange = createFunction;
+createFunction();


### PR DESCRIPTION
When the op is created for the first time changing the values does nothing until the equation changes.
Called the `createFunction();` on startup so it works as expected.   