### PR TITLE
fixed custom shader op crashing when creating a vec4

### DIFF
--- a/src/ops/base/Ops.Gl.Shader.CustomShader_v2/Ops.Gl.Shader.CustomShader_v2.js
+++ b/src/ops/base/Ops.Gl.Shader.CustomShader_v2/Ops.Gl.Shader.CustomShader_v2.js
@@ -212,7 +212,7 @@ function parseUniforms(src)
                                 group.push(newInputZ);
                                 vec.z = newInputZ;
                             }
-                            else if (num > 3)
+                            if (num > 3)
                             {
                                 const newInputW = op.inFloat(uniName + " W", 0);
                                 newInputW.onChange = function () { this.changed = true; }.bind(vec);


### PR DESCRIPTION
Creating a `vec4` would cause a crash, the `else if` statement meant that the `vec4` part was never reached.

