### PR TITLE
MatCapMaterialNew fixes

### DIFF
--- a/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/Ops.Gl.Shader.MatCapMaterialNew_v3.js
+++ b/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/Ops.Gl.Shader.MatCapMaterialNew_v3.js
@@ -1,0 +1,312 @@
+const
+    render = op.inTrigger("render"),
+    textureMatcap = op.inTexture("MatCap"),
+    textureDiffuse = op.inTexture("Diffuse"),
+    textureNormal = op.inTexture("Normal"),
+    textureSpec = op.inTexture("Specular Mask"),
+    textureSpecMatCap = op.inTexture("Specular MatCap"),
+    textureAo = op.inTexture("AO Texture"),
+    textureOpacity = op.inTexture("Opacity Texture"),
+    r = op.inValueSlider("r", 1),
+    g = op.inValueSlider("g", 1),
+    b = op.inValueSlider("b", 1),
+    pOpacity = op.inValueSlider("Opacity", 1),
+    aoIntensity = op.inValueSlider("AO Intensity", 1.0),
+    normalMapIntensity = op.inFloatSlider("Normal Map Intensity", 1),
+    repeatX = op.inValue("Repeat X", 1),
+    repeatY = op.inValue("Repeat Y", 1),
+    offsetX = op.inValue("Offset X", 0),
+    offsetY = op.inValue("Offset Y", 0),
+    projectCoords = op.inValueSelect("projectCoords", ["no", "xy", "yz", "xz"], "no"),
+    ssNormals = op.inValueBool("Screen Space Normals"),
+    calcTangents = op.inValueBool("calc normal tangents", true),
+    next = op.outTrigger("trigger"),
+    shaderOut = op.outObject("Shader");
+
+r.setUiAttribs({ "colorPick": true });
+
+const alphaMaskSource = op.inSwitch("Alpha Mask Source", ["Luminance", "R", "G", "B", "A"], "Luminance");
+alphaMaskSource.setUiAttribs({ "greyout": true });
+
+const texCoordAlpha = op.inValueBool("Opacity TexCoords Transform", false);
+const discardTransPxl = op.inValueBool("Discard Transparent Pixels");
+
+op.setPortGroup("Texture Opacity", [alphaMaskSource, texCoordAlpha, discardTransPxl]);
+op.setPortGroup("Texture Transforms", [aoIntensity, normalMapIntensity, repeatX, repeatY, offsetX, offsetY, calcTangents, projectCoords, ssNormals]);
+op.setPortGroup("Texture maps", [textureDiffuse, textureNormal, textureSpec, textureSpecMatCap, textureAo, textureOpacity]);
+op.setPortGroup("Color", [r, g, b, pOpacity]);
+
+const cgl = op.patch.cgl;
+const shader = new CGL.Shader(cgl, "MatCapMaterialNew");
+const uniOpacity = new CGL.Uniform(shader, "f", "opacity", pOpacity);
+
+shader.setModules(["MODULE_VERTEX_POSITION", "MODULE_COLOR", "MODULE_BEGIN_FRAG"]);
+shader.setSource(attachments.matcap_vert, attachments.matcap_frag);
+shaderOut.set(shader);
+
+const textureMatcapUniform = new CGL.Uniform(shader, "t", "texMatcap");
+let textureDiffuseUniform = null;
+let textureNormalUniform = null;
+let normalMapIntensityUniform = null;
+let textureSpecUniform = null;
+let textureSpecMatCapUniform = null;
+let textureAoUniform = null;
+const offsetUniform = new CGL.Uniform(shader, "2f", "texOffset", offsetX, offsetY);
+const repeatUniform = new CGL.Uniform(shader, "2f", "texRepeat", repeatX, repeatY);
+
+const aoIntensityUniform = new CGL.Uniform(shader, "f", "aoIntensity", aoIntensity);
+const colorUniform = new CGL.Uniform(shader, "4f", "inColor", r, g, b, pOpacity);
+b.uniform = new CGL.Uniform(shader, "f", "b", b);
+g.uniform = new CGL.Uniform(shader, "f", "g", g);
+r.uniform = new CGL.Uniform(shader, "f", "r", r);
+
+
+calcTangents.onChange = updateDefines;
+updateDefines();
+
+function updateDefines()
+{
+    if (calcTangents.get()) shader.define("CALC_TANGENT");
+    else shader.removeDefine("CALC_TANGENT");
+}
+
+ssNormals.onChange = function ()
+{
+    if (ssNormals.get())
+    {
+        if (cgl.glVersion < 2)
+        {
+            cgl.gl.getExtension("OES_standard_derivatives");
+            shader.enableExtension("GL_OES_standard_derivatives");
+        }
+
+        shader.define("CALC_SSNORMALS");
+    }
+    else shader.removeDefine("CALC_SSNORMALS");
+};
+
+projectCoords.onChange = function ()
+{
+    shader.toggleDefine("DO_PROJECT_COORDS_XY", projectCoords.get() == "xy");
+    shader.toggleDefine("DO_PROJECT_COORDS_YZ", projectCoords.get() == "yz");
+    shader.toggleDefine("DO_PROJECT_COORDS_XZ", projectCoords.get() == "xz");
+};
+
+textureMatcap.onChange = updateMatcap;
+
+function updateMatcap()
+{
+    if (!cgl.defaultMatcapTex)
+    {
+        const pixels = new Uint8Array(256 * 4);
+        for (let x = 0; x < 16; x++)
+        {
+            for (let y = 0; y < 16; y++)
+            {
+                let c = y * 16;
+                c *= Math.min(1, (x + y / 3) / 8);
+                pixels[(x + y * 16) * 4 + 0] = pixels[(x + y * 16) * 4 + 1] = pixels[(x + y * 16) * 4 + 2] = c;
+                pixels[(x + y * 16) * 4 + 3] = 255;
+            }
+        }
+
+        cgl.defaultMatcapTex = new CGL.Texture(cgl);
+        cgl.defaultMatcapTex.initFromData(pixels, 16, 16, CGL.Texture.FILTER_LINEAR, CGL.Texture.WRAP_REPEAT);
+    }
+}
+
+textureDiffuse.onChange = function ()
+{
+    if (textureDiffuse.get())
+    {
+        if (textureDiffuseUniform !== null) return;
+        shader.define("HAS_DIFFUSE_TEXTURE");
+        shader.removeUniform("texDiffuse");
+        textureDiffuseUniform = new CGL.Uniform(shader, "t", "texDiffuse");
+    }
+    else
+    {
+        shader.removeDefine("HAS_DIFFUSE_TEXTURE");
+        shader.removeUniform("texDiffuse");
+        textureDiffuseUniform = null;
+    }
+};
+
+textureNormal.onChange = function ()
+{
+    if (textureNormal.get())
+    {
+        if (textureNormalUniform !== null) return;
+        shader.define("HAS_NORMAL_TEXTURE");
+        shader.removeUniform("texNormal");
+        textureNormalUniform = new CGL.Uniform(shader, "t", "texNormal");
+        if (!normalMapIntensityUniform) normalMapIntensityUniform = new CGL.Uniform(shader, "f", "normalMapIntensity", normalMapIntensity);
+    }
+    else
+    {
+        shader.removeDefine("HAS_NORMAL_TEXTURE");
+        shader.removeUniform("texNormal");
+        textureNormalUniform = null;
+    }
+};
+
+textureAo.onChange = function ()
+{
+    if (textureAo.get())
+    {
+        if (textureAoUniform !== null) return;
+        shader.define("HAS_AO_TEXTURE");
+        shader.removeUniform("texAo");
+        textureAoUniform = new CGL.Uniform(shader, "t", "texAo");
+    }
+    else
+    {
+        shader.removeDefine("HAS_AO_TEXTURE");
+        shader.removeUniform("texAo");
+        textureAoUniform = null;
+    }
+};
+
+textureSpec.onChange = textureSpecMatCap.onChange = function ()
+{
+    if (textureSpec.get() && textureSpecMatCap.get())
+    {
+        if (textureSpecUniform !== null) return;
+        shader.define("USE_SPECULAR_TEXTURE");
+        shader.removeUniform("texSpec");
+        shader.removeUniform("texSpecMatCap");
+        textureSpecUniform = new CGL.Uniform(shader, "t", "texSpec");
+        textureSpecMatCapUniform = new CGL.Uniform(shader, "t", "texSpecMatCap");
+    }
+    else
+    {
+        shader.removeDefine("USE_SPECULAR_TEXTURE");
+        shader.removeUniform("texSpec");
+        shader.removeUniform("texSpecMatCap");
+        textureSpecUniform = null;
+        textureSpecMatCapUniform = null;
+    }
+};
+
+// TEX OPACITY
+
+function updateAlphaMaskMethod()
+{
+    if (alphaMaskSource.get() == "Alpha Channel") shader.define("ALPHA_MASK_ALPHA");
+    else shader.removeDefine("ALPHA_MASK_ALPHA");
+
+    if (alphaMaskSource.get() == "Luminance") shader.define("ALPHA_MASK_LUMI");
+    else shader.removeDefine("ALPHA_MASK_LUMI");
+
+    if (alphaMaskSource.get() == "R") shader.define("ALPHA_MASK_R");
+    else shader.removeDefine("ALPHA_MASK_R");
+
+    if (alphaMaskSource.get() == "G") shader.define("ALPHA_MASK_G");
+    else shader.removeDefine("ALPHA_MASK_G");
+
+    if (alphaMaskSource.get() == "B") shader.define("ALPHA_MASK_B");
+    else shader.removeDefine("ALPHA_MASK_B");
+}
+alphaMaskSource.onChange = updateAlphaMaskMethod;
+textureOpacity.onChange = updateOpacity;
+
+let textureOpacityUniform = null;
+
+function updateOpacity()
+{
+    if (textureOpacity.get())
+    {
+        if (textureOpacityUniform !== null) return;
+        shader.removeUniform("texOpacity");
+        shader.define("HAS_TEXTURE_OPACITY");
+        if (!textureOpacityUniform) textureOpacityUniform = new CGL.Uniform(shader, "t", "texOpacity");
+
+        alphaMaskSource.setUiAttribs({ "greyout": false });
+        discardTransPxl.setUiAttribs({ "greyout": false });
+        texCoordAlpha.setUiAttribs({ "greyout": false });
+    }
+    else
+    {
+        shader.removeUniform("texOpacity");
+        shader.removeDefine("HAS_TEXTURE_OPACITY");
+        textureOpacityUniform = null;
+
+        alphaMaskSource.setUiAttribs({ "greyout": true });
+        discardTransPxl.setUiAttribs({ "greyout": true });
+        texCoordAlpha.setUiAttribs({ "greyout": true });
+    }
+    updateAlphaMaskMethod();
+}
+
+discardTransPxl.onChange = function ()
+{
+    if (discardTransPxl.get()) shader.define("DISCARDTRANS");
+    else shader.removeDefine("DISCARDTRANS");
+};
+
+texCoordAlpha.onChange = function ()
+{
+    if (texCoordAlpha.get()) shader.define("TRANSFORMALPHATEXCOORDS");
+    else shader.removeDefine("TRANSFORMALPHATEXCOORDS");
+};
+
+op.onDelete = function ()
+{
+    // if(cgl.defaultMatcapTex)
+    // {
+    //     cgl.defaultMatcapTex.delete();
+    //     cgl.defaultMatcapTex=null;
+    // }
+};
+
+op.preRender = function ()
+{
+    shader.bind();
+};
+
+function checkUiErrors()
+{
+    if (textureSpec.get() && !textureSpecMatCap.get())
+    {
+        op.setUiError("specNoMatCapSpec", "You connected a specular texture but have not connected a specular matcap texture. You need to connect both texture inputs for the specular input to work.", 1);
+        op.setUiError("noSpecMatCapSpec", null);
+    }
+    else if (!textureSpec.get() && textureSpecMatCap.get())
+    {
+        op.setUiError("noSpecMatCapSpec", "You connected a specular matcap texture but have not connected a specular texture. You need to connect both texture inputs for the specular input to work.", 1);
+        op.setUiError("specNoMatCapSpec", null);
+    }
+    else if (textureSpec.get() && textureSpecMatCap.get())
+    {
+        op.setUiError("specNoMatCapSpec", null);
+        op.setUiError("noSpecMatCapSpec", null);
+    }
+    else
+    {
+        op.setUiError("specNoMatCapSpec", null);
+        op.setUiError("noSpecMatCapSpec", null);
+    }
+}
+
+render.onTriggered = function ()
+{
+    checkUiErrors();
+    if (!cgl.defaultMatcapTex) updateMatcap();
+    shader.popTextures();
+
+
+    const tex = textureMatcap.get() || cgl.defaultMatcapTex;
+    shader.pushTexture(textureMatcapUniform, tex.tex);
+
+    if (textureDiffuse.get() && textureDiffuseUniform) shader.pushTexture(textureDiffuseUniform, textureDiffuse.get().tex);
+    if (textureNormal.get() && textureNormalUniform) shader.pushTexture(textureNormalUniform, textureNormal.get().tex);
+    if (textureSpec.get() && textureSpecUniform) shader.pushTexture(textureSpecUniform, textureSpec.get().tex);
+    if (textureSpecMatCap.get() && textureSpecMatCapUniform) shader.pushTexture(textureSpecMatCapUniform, textureSpecMatCap.get().tex);
+    if (textureAo.get() && textureAoUniform) shader.pushTexture(textureAoUniform, textureAo.get().tex);
+    if (textureOpacity.get() && textureOpacityUniform) shader.pushTexture(textureOpacityUniform, textureOpacity.get().tex);
+
+
+    cgl.pushShader(shader);
+    next.trigger();
+    cgl.popShader();
+};

--- a/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/Ops.Gl.Shader.MatCapMaterialNew_v3.json
+++ b/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/Ops.Gl.Shader.MatCapMaterialNew_v3.json
@@ -1,0 +1,175 @@
+{
+    "id": "c1dd6e76-61b4-471a-b8d1-f550a5a9a4f4",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "simod",
+            "date": 1599664419300
+        },
+        {
+            "message": "Ops.User.simod.MatCapMaterialNew_v3 renamed to Ops.Gl.Shader.MatCapMaterialNew_v3",
+            "author": "simod",
+            "date": 1599664555174
+        }
+    ],
+    "authorName": "simod",
+    "created": 1599664445091,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "1",
+                "name": "render"
+            },
+            {
+                "type": "2",
+                "name": "MatCap"
+            },
+            {
+                "type": "2",
+                "name": "Diffuse",
+                "group": "Texture maps"
+            },
+            {
+                "type": "2",
+                "name": "Normal",
+                "group": "Texture maps"
+            },
+            {
+                "type": "2",
+                "name": "Specular Mask",
+                "group": "Texture maps"
+            },
+            {
+                "type": "2",
+                "name": "Specular MatCap",
+                "group": "Texture maps"
+            },
+            {
+                "type": "2",
+                "name": "AO Texture",
+                "group": "Texture maps"
+            },
+            {
+                "type": "2",
+                "name": "Opacity Texture",
+                "group": "Texture maps"
+            },
+            {
+                "type": "0",
+                "name": "r",
+                "group": "Color",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "g",
+                "group": "Color",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "b",
+                "group": "Color",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Opacity",
+                "group": "Color",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "AO Intensity",
+                "group": "Texture Transforms",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Normal Map Intensity",
+                "group": "Texture Transforms",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Repeat X",
+                "group": "Texture Transforms",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Repeat Y",
+                "group": "Texture Transforms",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Offset X",
+                "group": "Texture Transforms",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Offset Y",
+                "group": "Texture Transforms",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "projectCoords index",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "projectCoords",
+                "group": "Texture Transforms",
+                "subType": "string"
+            },
+            {
+                "type": "0",
+                "name": "Screen Space Normals",
+                "group": "Texture Transforms",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "calc normal tangents",
+                "group": "Texture Transforms",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Alpha Mask Source index",
+                "subType": "integer"
+            },
+            {
+                "type": "5",
+                "name": "Alpha Mask Source",
+                "group": "Texture Opacity"
+            },
+            {
+                "type": "0",
+                "name": "Opacity TexCoords Transform",
+                "group": "Texture Opacity",
+                "subType": "boolean"
+            },
+            {
+                "type": "0",
+                "name": "Discard Transparent Pixels",
+                "group": "Texture Opacity",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "1",
+                "name": "trigger"
+            },
+            {
+                "type": "2",
+                "name": "Shader"
+            }
+        ],
+        "name": "Ops.Gl.Shader.MatCapMaterialNew_v3"
+    }
+}

--- a/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.frag
+++ b/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.frag
@@ -1,0 +1,166 @@
+{{MODULES_HEAD}}
+
+IN vec3 norm;
+IN vec2 texCoord;
+IN vec3 v_viewDirection;
+IN vec3 transformedNormal;
+
+UNI vec4 inColor;
+
+UNI sampler2D texMatcap;
+
+#ifdef HAS_DIFFUSE_TEXTURE
+   UNI sampler2D texDiffuse;
+#endif
+
+#ifdef USE_SPECULAR_TEXTURE
+   UNI sampler2D texSpec;
+   UNI sampler2D texSpecMatCap;
+#endif
+
+#ifdef HAS_AO_TEXTURE
+    UNI sampler2D texAo;
+    UNI float aoIntensity;
+#endif
+
+#ifdef HAS_NORMAL_TEXTURE
+    IN vec3 vBiTangent;
+    IN vec3 vTangent;
+    IN mat3 normalMatrix;
+
+    UNI sampler2D texNormal;
+    UNI float normalMapIntensity;
+#endif
+
+#ifdef HAS_TEXTURE_OPACITY
+    UNI sampler2D texOpacity;
+#endif
+
+#ifdef CALC_SSNORMALS
+    IN vec3 eye_relative_pos;
+
+    // from https://www.enkisoftware.com/devlogpost-20150131-1-Normal_generation_in_the_pixel_shader
+    vec3 CalculateScreenSpaceNormals() {
+    	vec3 dFdxPos = dFdx(eye_relative_pos);
+    	vec3 dFdyPos = dFdy(eye_relative_pos);
+    	vec3 screenSpaceNormal = normalize( cross(dFdxPos, dFdyPos));
+        return normalize(screenSpaceNormal);
+    }
+#endif
+
+// * taken & modified from https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
+vec2 getMatCapUV(vec3 normal) {
+    vec3 viewDir = normalize(v_viewDirection);
+	vec3 x = normalize(vec3(viewDir.z, 0.0, - viewDir.x));
+	vec3 y = cross(viewDir, x);
+	vec2 uv = vec2(dot(x, normal), dot(y, normal)) * 0.495 + 0.5; // 0.495 to remove artifacts caused by undersized matcap disks
+
+	return uv;
+}
+
+void main()
+{
+    vec3 viewSpaceNormal = normalize(transformedNormal);
+
+    #ifdef HAS_TEXTURES
+        vec2 texCoords = texCoord;
+        {{MODULE_BEGIN_FRAG}}
+    #endif
+
+
+    #ifdef CALC_SSNORMALS
+        viewSpaceNormal = CalculateScreenSpaceNormals();
+    #endif
+
+
+   #ifdef HAS_NORMAL_TEXTURE
+
+        vec3 normalFromMap =texture( texNormal, texCoord ).xyz * 2.0 - 1.0;
+
+        normalFromMap = normalize(normalFromMap * normalMapIntensity);
+
+        vec3 tangent;
+        vec3 binormal;
+
+        #ifdef CALC_TANGENT
+            vec3 c1 = cross(norm, vec3(0.0, 0.0, 1.0));
+            vec3 c2 = cross(norm, vec3(0.0, 1.0, 0.0));
+
+            tangent = c1;
+            tangent = normalize(tangent);
+            binormal = cross(viewSpaceNormal, tangent);
+            binormal = normalize(binormal);
+        #endif
+
+        #ifndef CALC_TANGENT
+            tangent = normalize(normalMatrix * vTangent);
+            binormal = normalize(normalMatrix * cross(normalize(viewSpaceNormal), normalize(vBiTangent)));
+        #endif
+
+        normalFromMap = normalize(
+            tangent * normalFromMap.x
+            + binormal * normalFromMap.y
+            + viewSpaceNormal * normalFromMap.z
+        );
+
+        vec3 mixedNormal = normalize(viewSpaceNormal + normalFromMap * normalMapIntensity);
+
+        viewSpaceNormal = mixedNormal;
+    #endif
+
+    vec4 col = texture(texMatcap, getMatCapUV(viewSpaceNormal));
+
+    #ifdef HAS_DIFFUSE_TEXTURE
+        col = col*texture(texDiffuse, texCoords);
+    #endif
+
+    col.rgb *= inColor.rgb;
+
+
+    #ifdef HAS_AO_TEXTURE
+        col = col
+            * mix(
+                vec4(1.0,1.0,1.0,1.0),
+                texture(texAo, texCoords),
+                aoIntensity
+            );
+    #endif
+
+    #ifdef USE_SPECULAR_TEXTURE
+        vec4 spec = texture(texSpecMatCap, getMatCapUV(viewSpaceNormal));
+        spec *= texture(texSpec, texCoords);
+        col += spec;
+    #endif
+
+    col.a *= inColor.a;
+
+    #ifdef HAS_TEXTURE_OPACITY
+        #ifdef TRANSFORMALPHATEXCOORDS
+            texCoords=vec2(texCoord.s,1.0-texCoord.t);
+            texCoords.y = 1. - texCoords.y;
+        #endif
+        #ifdef ALPHA_MASK_ALPHA
+            col.a*=texture(texOpacity,texCoords).a;
+        #endif
+        #ifdef ALPHA_MASK_LUMI
+            col.a*=dot(vec3(0.2126,0.7152,0.0722), texture(texOpacity,texCoords).rgb);
+        #endif
+        #ifdef ALPHA_MASK_R
+            col.a*=texture(texOpacity,texCoords).r;
+        #endif
+        #ifdef ALPHA_MASK_G
+            col.a*=texture(texOpacity,texCoords).g;
+        #endif
+        #ifdef ALPHA_MASK_B
+            col.a*=texture(texOpacity,texCoords).b;
+        #endif
+
+        #ifdef DISCARDTRANS
+            if(col.a < 0.2) discard;
+        #endif
+    #endif
+
+    {{MODULE_COLOR}}
+
+    outColor = col;
+}

--- a/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.vert
+++ b/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.vert
@@ -1,0 +1,114 @@
+IN vec3 vPosition;
+IN vec2 attrTexCoord;
+IN vec3 attrVertNormal;
+IN float attrVertIndex;
+IN vec3 attrTangent;
+IN vec3 attrBiTangent;
+
+#ifdef HAS_NORMAL_TEXTURE
+    OUT vec3 vBiTangent;
+    OUT vec3 vTangent;
+#endif
+
+UNI mat4 projMatrix;
+UNI mat4 modelMatrix;
+UNI mat4 viewMatrix;
+UNI vec3 camPos;
+
+OUT vec2 texCoord;
+OUT vec3 norm;
+OUT vec3 fragPos;
+OUT vec3 v_viewDirection;
+OUT vec3 transformedNormal;
+OUT mat3 normalMatrix;
+UNI vec2 texOffset;
+UNI vec2 texRepeat;
+
+{{MODULES_HEAD}}
+
+#ifdef CALC_SSNORMALS
+    // from https://www.enkisoftware.com/devlogpost-20150131-1-Normal_generation_in_the_pixel_shader
+    OUT vec3 eye_relative_pos;
+#endif
+
+
+
+
+ mat3 transposeMat3(mat3 m)
+ {
+     return mat3(m[0][0], m[1][0], m[2][0],
+         m[0][1], m[1][1], m[2][1],
+         m[0][2], m[1][2], m[2][2]);
+ }
+
+ mat3 inverseMat3(mat3 m)
+ {
+     float a00 = m[0][0], a01 = m[0][1], a02 = m[0][2];
+     float a10 = m[1][0], a11 = m[1][1], a12 = m[1][2];
+     float a20 = m[2][0], a21 = m[2][1], a22 = m[2][2];
+
+     float b01 = a22 * a11 - a12 * a21;
+     float b11 = -a22 * a10 + a12 * a20;
+     float b21 = a21 * a10 - a11 * a20;
+
+     float det = a00 * b01 + a01 * b11 + a02 * b21;
+
+     return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11),
+         b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10),
+         b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;
+ }
+
+void main()
+{
+    texCoord = texRepeat * vec2(attrTexCoord.x, attrTexCoord.y) + texOffset;
+    texCoord.y = 1. - texCoord.y;
+
+    norm=attrVertNormal;
+
+    mat4 mMatrix=modelMatrix;
+    mat4 mvMatrix;
+    vec3 tangent=attrTangent;
+    vec3 bitangent=attrBiTangent;
+
+    #ifdef HAS_NORMAL_TEXTURE
+        vTangent=attrTangent;
+        vBiTangent=attrBiTangent;
+    #endif
+
+    vec4 pos = vec4( vPosition, 1. );
+
+    {{MODULE_VERTEX_POSITION}}
+
+
+    mvMatrix= viewMatrix * mMatrix;
+    normalMatrix = transposeMat3(inverseMat3(mat3(mMatrix)));
+
+    #ifdef DO_PROJECT_COORDS_XY
+       texCoord=(projMatrix * mvMatrix*pos).xy*0.1;
+       texCoord.y = 1. - texCoord.y;
+    #endif
+
+    #ifdef DO_PROJECT_COORDS_YZ
+       texCoord=(projMatrix * mvMatrix*pos).yz*0.1;
+       texCoord.y = 1. - texCoord.y;
+    #endif
+
+    #ifdef DO_PROJECT_COORDS_XZ
+        texCoord=(projMatrix * mvMatrix*pos).xz*0.1;
+        texCoord.y = 1. - texCoord.y;
+    #endif
+
+
+    fragPos = vec3((mMatrix) * pos);
+    v_viewDirection = camPos - fragPos;
+
+    #ifdef CALC_SSNORMALS
+        eye_relative_pos = -v_viewDirection;
+    #endif
+
+    v_viewDirection = normalize(v_viewDirection);
+    transformedNormal = normalize(mat3(normalMatrix) * norm);
+
+   gl_Position = projMatrix * mvMatrix * pos;
+
+}


### PR DESCRIPTION
- Remove unused code
- Matcapping dependant on view direction & mesh position now
- Rename Specular Texture to Specular Matcap Mask (for clarity)
- UI warning when specular mask & specular matcap are not connected at the same time
- Fix MeshInstancer weirdness
- Correct screen space normals
- Correct normal mapping, works with screen space normals swell
- Add normal map intensity
- R, g, b, alpha —> inColor uniform

Before merging, you can check this patch for the new version here:

https://dev.cables.gl/edit/e8vhtf


I tried my best to test everything. I am unsure about the project coords as I don't know what they are for/how to use them. Maybe you can help me with that @pandrr ?