### PR TITLE
new op points_plane_v2, fix for points_plane old

### DIFF
--- a/src/ops/base/Ops.Points.PointsPlane_v2/Ops.Points.PointsPlane_v2.js
+++ b/src/ops/base/Ops.Points.PointsPlane_v2/Ops.Points.PointsPlane_v2.js
@@ -1,8 +1,8 @@
 const
     inNumX = op.inValueInt("Rows", 32),
     inNumY = op.inValueInt("Columns", 32),
-    inWidth = op.inValueInt("Width", 2),
-    inHeight = op.inValueInt("Height", 2),
+    inHeight = op.inFloat("Width", 2),
+    inWidth = op.inFloat("Height", 2),
     inCenter = op.inValueBool("Center", true),
     outArr = op.outArray("Result"),
     outTotalPoints = op.outNumber("Total points"),
@@ -10,10 +10,10 @@ const
     outRowNums = op.outArray("Row Numbers"),
     outColNums = op.outArray("Column Numbers");
 
-inNumX.onChange = generate;
-inNumY.onChange = generate;
-inCenter.onChange = generate;
-inWidth.onChange = generate;
+inNumX.onChange =
+inNumY.onChange =
+inCenter.onChange =
+inWidth.onChange =
 inHeight.onChange = generate;
 
 const arr = [];
@@ -25,10 +25,29 @@ generate();
 function generate()
 {
     arr.length = 0;
-    const numX = Math.max(1, inNumX.get());
-    const numY = Math.max(1, inNumY.get());
-    const stepY = inHeight.get() / (numY - 1);
-    const stepX = inWidth.get() / (numX - 1);
+    const numX = Math.max(0, inNumX.get());
+    const numY = Math.max(0, inNumY.get());
+
+    let stepX = 0;
+    let stepY = 0;
+
+    // to avoid divide by zero
+    if (numX == 1)
+    {
+        stepX = inWidth.get() / (numX);
+    }
+    else
+    {
+        stepX = inWidth.get() / (numX - 1);
+    }
+    if (numY == 1)
+    {
+        stepY = inHeight.get() / (numY);
+    }
+    else
+    {
+        stepY = inHeight.get() / (numY - 1);
+    }
 
     let i = 0;
 
@@ -37,24 +56,26 @@ function generate()
 
     if (inCenter.get())
     {
-        centerX = (inWidth.get()) / 2;
+        centerX = inWidth.get() / 2;
         centerY = inHeight.get() / 2;
     }
 
     const l = Math.floor(numX) * Math.floor(numY) * 3;
 
     arr.length = l;
-    arrColNums.length = arrRowNums.length = l / 3;
+    arrColNums.length = l / 3;
+    arrRowNums.length = l / 3;
 
-    for (let x = 0; x < numX; x++)
+    for (let y = 0; y < numY; y++)
     {
-        for (let y = 0; y < numY; y++)
+        for (let x = 0; x < numX; x++)
         {
-            arrColNums[i / 3] = x;
-            arrRowNums[i / 3] = y;
+            arrColNums[i / 3] = y;
+            arrRowNums[i / 3] = x;
 
-            arr[i++] = stepX * x - centerX;
             arr[i++] = stepY * y - centerY;
+            arr[i++] = stepX * x - centerX;
+
             arr[i++] = 0;
         }
     }

--- a/src/ops/base/Ops.Points.PointsPlane_v2/Ops.Points.PointsPlane_v2.json
+++ b/src/ops/base/Ops.Points.PointsPlane_v2/Ops.Points.PointsPlane_v2.json
@@ -1,0 +1,66 @@
+{
+    "id": "d453f898-17d4-4e2c-b8c7-7b7b34c0ff68",
+    "changelog": [
+        {
+            "message": "created op",
+            "author": "pandur",
+            "date": 1599741464116
+        }
+    ],
+    "authorName": "pandur",
+    "created": 1599741475800,
+    "layout": {
+        "portsIn": [
+            {
+                "type": "0",
+                "name": "Rows",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Columns",
+                "subType": "integer"
+            },
+            {
+                "type": "0",
+                "name": "Width",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Height",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Center",
+                "subType": "boolean"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": "3",
+                "name": "Result"
+            },
+            {
+                "type": "0",
+                "name": "Total points",
+                "subType": "number"
+            },
+            {
+                "type": "0",
+                "name": "Array length",
+                "subType": "number"
+            },
+            {
+                "type": "3",
+                "name": "Row Numbers"
+            },
+            {
+                "type": "3",
+                "name": "Column Numbers"
+            }
+        ],
+        "name": "Ops.Points.PointsPlane_v2"
+    }
+}


### PR DESCRIPTION
 #1724
Fix for pointsPlane old, numX,numY 0 caused a crash.
Made a new version as the old one had multiple problems and changing the original one would alter all patches that used it
- Divide by zero when columns or rows was set to 1
- Rows and columns were swapped around, same for arrays out with columns and rows.

Tested and now works correctly.

