### PR TITLE
Fixes for Matcapping, details see comment

### DIFF
--- a/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/att_phong.frag
+++ b/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/att_phong.frag
@@ -28,6 +28,10 @@ UNI vec4 inMaterialProperties;
     UNI vec2 inFresnelWidthExponent;
 #endif
 
+#ifdef ENVMAP_MATCAP
+    IN vec3 viewSpaceNormal;
+    IN vec3 viewSpacePosition;
+#endif
 
 struct Light {
     vec3 color;
@@ -128,12 +132,11 @@ const float EIGHT_PI = (8. * PI);
 
 
             // * taken & modified from https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
-            vec2 getMatCapUV(vec3 normal) {
-                vec3 viewDir = normalize(v_viewDirection);
+            vec2 getMatCapUV(vec3 viewSpacePosition, vec3 viewSpaceNormal) {
+                vec3 viewDir = normalize(-viewSpacePosition);
             	vec3 x = normalize(vec3(viewDir.z, 0.0, - viewDir.x));
-            	vec3 y = cross(viewDir, x);
-            	vec2 uv = vec2(dot(x, normal), dot(y, normal)) * 0.495 + 0.5; // 0.495 to remove artifacts caused by undersized matcap disks
-
+            	vec3 y = normalize(cross(viewDir, x));
+            	vec2 uv = vec2(dot(x, viewSpaceNormal), dot(y, viewSpaceNormal)) * 0.495 + 0.5; // 0.495 to remove artifacts caused by undersized matcap disks
             	return uv;
             }
         #endif
@@ -451,24 +454,24 @@ void main()
     #ifdef HAS_TEXTURE_ENV
         vec3 luminanceColor = vec3(0.);
 
-        float environmentMapWidth = inEnvMapWidth;
-        float glossyExponent = inMaterialProperties.SHININESS;
-        float glossyCoefficient = inMaterialProperties.SPECULAR_AMT;
-
-        vec3 envMapNormal =  normal;
-        vec3 reflectDirection = reflect(normalize(-viewDirection), normal);
-
-        float lambertianCoefficient = dot(viewDirection, reflectDirection); //0.44; // TODO: need prefiltered map for this
-        // lambertianCoefficient = 1.;
-        float specularAngle = max(dot(reflectDirection, viewDirection), 0.);
-        float specularFactor = pow(specularAngle, max(0., inMaterialProperties.SHININESS));
-
-        glossyExponent = specularFactor;
-
-        float maxMIPLevel = 10.;
-        float MIPlevel = log2(environmentMapWidth / 1024. * sqrt(3.)) - 0.5 * log2(glossyExponent + 1.);
-
         #ifndef ENVMAP_MATCAP
+            float environmentMapWidth = inEnvMapWidth;
+            float glossyExponent = inMaterialProperties.SHININESS;
+            float glossyCoefficient = inMaterialProperties.SPECULAR_AMT;
+
+            vec3 envMapNormal =  normal;
+            vec3 reflectDirection = reflect(normalize(-viewDirection), normal);
+
+            float lambertianCoefficient = dot(viewDirection, reflectDirection); //0.44; // TODO: need prefiltered map for this
+            // lambertianCoefficient = 1.;
+            float specularAngle = max(dot(reflectDirection, viewDirection), 0.);
+            float specularFactor = pow(specularAngle, max(0., inMaterialProperties.SHININESS));
+
+            glossyExponent = specularFactor;
+
+            float maxMIPLevel = 10.;
+            float MIPlevel = log2(environmentMapWidth / 1024. * sqrt(3.)) - 0.5 * log2(glossyExponent + 1.);
+
             luminanceColor = inEnvMapIntensity * (
                 inDiffuseColor.rgb *
                 SAMPLETEX(texEnv, envMapNormal, maxMIPLevel).rgb
@@ -478,10 +481,11 @@ void main()
         #endif
         #ifdef ENVMAP_MATCAP
             luminanceColor = inEnvMapIntensity * (
-                inDiffuseColor.rgb
-                * textureLod(texEnv, getMatCapUV(envMapNormal), maxMIPLevel).rgb
-                +
-                glossyCoefficient * textureLod(texEnv, getMatCapUV(reflectDirection), MIPlevel).rgb
+                texture(texEnv, getMatCapUV(viewSpacePosition, viewSpaceNormal)).rgb
+                //inDiffuseColor.rgb
+                //* textureLod(texEnv, getMatCapUV(envMapNormal), maxMIPLevel).rgb
+                //+
+                //glossyCoefficient * textureLod(texEnv, getMatCapUV(reflectDirection), MIPlevel).rgb
             );
         #endif
 

--- a/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/att_phong.vert
+++ b/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/att_phong.vert
@@ -43,7 +43,11 @@ UNI vec3 camPos;
 UNI mat4 projMatrix;
 UNI mat4 viewMatrix;
 UNI mat4 modelMatrix;
-// UNI mat4 normalMatrix;
+
+#ifdef ENVMAP_MATCAP
+    OUT vec3 viewSpaceNormal;
+    OUT vec3 viewSpacePosition;
+#endif
 
 
 mat3 transposeMat3(mat3 m)
@@ -124,5 +128,10 @@ void main()
     v_viewDirection = normalize(camPos - fragPos);
     // modelPos=mMatrix*pos;
 
+    #ifdef ENVMAP_MATCAP
+        mat3 viewSpaceNormalMatrix = normalMatrix = transposeMat3(inverseMat3(mat3(mvMatrix)));
+        viewSpaceNormal = normalize(viewSpaceNormalMatrix * norm);
+        viewSpacePosition = vec3(mvMatrix * pos);
+    #endif
     gl_Position = projMatrix * mvMatrix * pos;
 }

--- a/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.frag
+++ b/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.frag
@@ -51,8 +51,8 @@ UNI sampler2D texMatcap;
 #endif
 
 // * taken & modified from https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderLib/meshmatcap_frag.glsl.js
-vec2 getMatCapUV(vec3 viewPosition, vec3 normal) {
-    vec3 viewDir = normalize(-viewPosition);
+vec2 getMatCapUV(vec3 viewSpacePosition, vec3 normal) {
+    vec3 viewDir = normalize(-viewSpacePosition);
 	vec3 x = normalize(vec3(viewDir.z, 0.0, - viewDir.x));
 	vec3 y = normalize(cross(viewDir, x));
 	vec2 uv = vec2(dot(x, normal), dot(y, normal)) * 0.495 + 0.5; // 0.495 to remove artifacts caused by undersized matcap disks

--- a/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.vert
+++ b/src/ops/base/Ops.Gl.Shader.MatCapMaterialNew_v3/att_matcap.vert
@@ -26,7 +26,7 @@ UNI vec3 camPos;
 #endif
 
 OUT mat3 normalMatrix;
-OUT vec3 v_viewDirection;
+OUT vec3 viewSpacePosition;
 OUT vec3 transformedNormal;
 
 {{MODULES_HEAD}}
@@ -80,17 +80,18 @@ void main()
     {{MODULE_VERTEX_POSITION}}
 
     mvMatrix = viewMatrix * mMatrix;
-    normalMatrix = transposeMat3(inverseMat3(mat3(mMatrix)));
+    vec3 normal = attrVertNormal;
 
-    vec3 fragPos = vec3((mMatrix) * pos);
-    v_viewDirection = camPos - fragPos;
+    normalMatrix = transposeMat3(inverseMat3(mat3(mvMatrix)));
+
+    vec3 fragPos = vec3((mvMatrix) * pos);
+    viewSpacePosition = normalize(fragPos);
 
     #ifdef CALC_SSNORMALS
-        eye_relative_pos = -v_viewDirection;
+        eye_relative_pos = -(vec3(viewMatrix * vec4(camPos, 1.)) - fragPos);
     #endif
 
-    v_viewDirection = normalize(v_viewDirection);
-    transformedNormal = normalize(mat3(normalMatrix) * attrVertNormal);
+    transformedNormal = normalize(mat3(normalMatrix) * normal);
 
    gl_Position = projMatrix * mvMatrix * pos;
 


### PR DESCRIPTION
MatCapMaterialNew_v3
- [x] fix wrong matcap reflections when looking at mesh from above (move all calculations to view space instead of model space)
- [x] fix normal mapping


PhongMaterial_v5
- [x] MatCap Environment Map now only uses the normal vector, no more artifacts, just simple matcapping.


If desired, I can move the fixes to admin ops first so you can test them @pandrr.

I did my best to make sure everything was correct.