### PR TITLE
PhongMaterial_v5: Add emissive texture mask, greyouts & multiple bugfixes

### DIFF
--- a/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/Ops.Gl.Phong.PhongMaterial_v5.js
+++ b/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/Ops.Gl.Phong.PhongMaterial_v5.js
@@ -120,7 +120,6 @@ let uniEmissiveColor = null;
 
 inEmissiveActive.onChange = () =>
 {
-    op.log("emissive active on change");
     shader.toggleDefine("ADD_EMISSIVE_COLOR", inEmissiveActive);
 
     if (inEmissiveActive.get())
@@ -134,7 +133,6 @@ inEmissiveActive.onChange = () =>
     }
     else
     {
-        op.log("ayayay");
         inEmissiveTexture.setUiAttribs({ "greyout": true });
         inEmissiveMaskTexture.setUiAttribs({ "greyout": true });
         inEmissiveIntensity.setUiAttribs({ "greyout": true });

--- a/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/Ops.Gl.Phong.PhongMaterial_v5.json
+++ b/src/ops/base/Ops.Gl.Phong.PhongMaterial_v5/Ops.Gl.Phong.PhongMaterial_v5.json
@@ -198,6 +198,12 @@
             },
             {
                 "type": 2,
+                "name": "Emissive Mask",
+                "group": "Textures",
+                "objType": "texture"
+            },
+            {
+                "type": 2,
                 "name": "Opacity Texture",
                 "group": "Textures",
                 "objType": "texture"
@@ -265,6 +271,12 @@
             {
                 "type": 0,
                 "name": "Emissive Intensity",
+                "group": "Texture Intensities",
+                "subType": "number"
+            },
+            {
+                "type": 0,
+                "name": "Emissive Mask Intensity",
                 "group": "Texture Intensities",
                 "subType": "number"
             },


### PR DESCRIPTION
- emissive texture now blends correctly with diffuse color
- add emissive mask texture
- add greyouts to texture intensities
- add greyouts to emissive textures when emissive is not active
- fix bug where not all texture update methods would be called on initialization