### PR TITLE
Added RG16F pixelformat for framebuffer2

### DIFF
--- a/src/core/cgl/cgl_framebuffer2.js
+++ b/src/core/cgl/cgl_framebuffer2.js
@@ -251,7 +251,7 @@ Framebuffer2.prototype.setSize = function (w, h)
 
                 internFormat = this._cgl.gl.R11F_G11F_B10F;
             }
-			else if (this._options.pixelFormat == Texture.PFORMATSTR_RG16F)
+            else if (this._options.pixelFormat == Texture.PFORMATSTR_RG16F)
             {
                 const extcb = this._cgl.enableExtension("EXT_color_buffer_float");
 

--- a/src/core/cgl/cgl_framebuffer2.js
+++ b/src/core/cgl/cgl_framebuffer2.js
@@ -251,6 +251,20 @@ Framebuffer2.prototype.setSize = function (w, h)
 
                 internFormat = this._cgl.gl.R11F_G11F_B10F;
             }
+			else if (this._options.pixelFormat == Texture.PFORMATSTR_RG16F)
+            {
+                const extcb = this._cgl.enableExtension("EXT_color_buffer_float");
+
+                if (!this._cgl.enableExtension("OES_texture_float_linear"))
+                {
+                    console.log("no linear pixelformat,switching to nearest");
+                    this._options.filter = Texture.FILTER_NEAREST;
+                    this.setFilter(this._options.filter);
+                }
+
+
+                internFormat = this._cgl.gl.RG16F;
+            }
         }
 
         if (this._options.multisampling && this._options.multisamplingSamples)

--- a/src/core/cgl/cgl_texture.js
+++ b/src/core/cgl/cgl_texture.js
@@ -281,14 +281,14 @@ Texture.prototype.setSize = function (w, h)
                 internalFormat = this._cgl.gl.RGBA16F;
                 dataType = this._cgl.gl.FLOAT;
             }
-			
+            
             if (this.pixelFormat == Texture.PFORMATSTR_RG16F)
             {
                 internalFormat = this._cgl.gl.RG16F;
                 dataType = this._cgl.gl.FLOAT;
-				dataFormat = this._cgl.gl.RG;
+                dataFormat = this._cgl.gl.RG;
             }
-			
+            
             if (this.pixelFormat == Texture.PFORMATSTR_R11FG11FB10F)
             {
                 internalFormat = this._cgl.gl.R11F_G11F_B10F;

--- a/src/core/cgl/cgl_texture.js
+++ b/src/core/cgl/cgl_texture.js
@@ -281,7 +281,14 @@ Texture.prototype.setSize = function (w, h)
                 internalFormat = this._cgl.gl.RGBA16F;
                 dataType = this._cgl.gl.FLOAT;
             }
-
+			
+            if (this.pixelFormat == Texture.PFORMATSTR_RG16F)
+            {
+                internalFormat = this._cgl.gl.RG16F;
+                dataType = this._cgl.gl.FLOAT;
+				dataFormat = this._cgl.gl.RG;
+            }
+			
             if (this.pixelFormat == Texture.PFORMATSTR_R11FG11FB10F)
             {
                 internalFormat = this._cgl.gl.R11F_G11F_B10F;
@@ -1093,12 +1100,13 @@ Texture.PFORMATSTR_RGBA8UB = "RGBA 8bit ubyte";
 Texture.PFORMATSTR_RGBA16F = "RGBA 16bit float";
 Texture.PFORMATSTR_R11FG11FB10F = "RGB 11/11/10bit float";
 Texture.PFORMATSTR_RGBA32F = "RGBA 32bit float";
+Texture.PFORMATSTR_RG16F = "RG 16bit float";
 
-Texture.PIXELFORMATS = [Texture.PFORMATSTR_RGBA8UB, Texture.PFORMATSTR_R11FG11FB10F, Texture.PFORMATSTR_RGBA16F, Texture.PFORMATSTR_RGBA32F];
+Texture.PIXELFORMATS = [Texture.PFORMATSTR_RGBA8UB, Texture.PFORMATSTR_R11FG11FB10F, Texture.PFORMATSTR_RGBA16F, Texture.PFORMATSTR_RGBA32F, Texture.PFORMATSTR_RG16F];
 
 Texture.isPixelFormatFloat = (pxlfrmt) =>
 {
-    return (pxlfrmt == Texture.PFORMATSTR_RGBA32F || pxlfrmt == Texture.PFORMATSTR_R11FG11FB10F || pxlfrmt == Texture.PFORMATSTR_RGBA16F);
+    return (pxlfrmt == Texture.PFORMATSTR_RGBA32F || pxlfrmt == Texture.PFORMATSTR_R11FG11FB10F || pxlfrmt == Texture.PFORMATSTR_RGBA16F || pxlfrmt == Texture.PFORMATSTR_RG16F);
 };
 
 


### PR DESCRIPTION
Should be used for BRDF LUT. Not 100% sure that this is all the changes required for adding a new pixelFormat.