### PR TITLE
Added more Clearcoat options to PBR Material and thin film iridescence

### DIFF
--- a/src/ops/base/Ops.Gl.Pbr.PbrMaterial/Ops.Gl.Pbr.PbrMaterial.js
+++ b/src/ops/base/Ops.Gl.Pbr.PbrMaterial/Ops.Gl.Pbr.PbrMaterial.js
@@ -20,6 +20,11 @@ const inClearCoatRoughness = op.inFloatSlider("Clear Coat Roughness", 0.5);
 const inUseNormalMapForCC = op.inValueBool("Use Normal map for Clear Coat", false);
 const inTexClearCoatNormal = op.inTexture("Clear Coat Normal map");
 
+const inUseThinFilm = op.inValueBool("Use Thin Film", false);
+const inThinFilmIntensity = op.inFloatSlider("Thin Film Intensity", 1.0);
+const inThinFilmIOR = op.inFloat("Thin Film IOR", 1.3);
+const inThinFilmThickness = op.inFloat("Thin Film Thickness (nm)", 600.0);
+
 const inTonemapping = op.inSwitch("Tonemapping", ["sRGB", "HejiDawson", "Photographic"], "sRGB");
 const inTonemappingExposure = op.inFloat("Exposure", 1.0);
 
@@ -63,6 +68,7 @@ op.setPortGroup("Textures", [inTexAlbedo, inTexAORM, inTexNormal, inTexHeight, i
 op.setPortGroup("Lighting", [inDiffuseIntensity, inSpecularIntensity, inLightmapIntensity, inLightmapRGBE, inTexIBLLUT, inTexIrradiance, inTexPrefiltered, inMipLevels]);
 op.setPortGroup("Tonemapping", [inTonemapping, inTonemappingExposure]);
 op.setPortGroup("Clear Coat", [inUseClearCoat, inClearCoatIntensity, inClearCoatRoughness, inUseNormalMapForCC, inTexClearCoatNormal]);
+op.setPortGroup("Thin Film Iridescence", [inUseThinFilm, inThinFilmIntensity, inThinFilmIOR, inThinFilmThickness]);
 // globals
 const PBRShader = new CGL.Shader(cgl, "PBRShader");
 PBRShader.setModules(["MODULE_VERTEX_POSITION", "MODULE_COLOR", "MODULE_BEGIN_FRAG"]);
@@ -144,6 +150,10 @@ const inHeightDepthUniform = new CGL.Uniform(PBRShader, "f", "_HeightDepth", inH
 const inClearCoatIntensityUniform = new CGL.Uniform(PBRShader, "f", "_ClearCoatIntensity", inClearCoatIntensity);
 const inClearCoatRoughnessUniform = new CGL.Uniform(PBRShader, "f", "_ClearCoatRoughness", inClearCoatRoughness);
 
+const inThinFilmIntensityUniform = new CGL.Uniform(PBRShader, "f", "_ThinFilmIntensity", inThinFilmIntensity);
+const inThinFilmIORUniform = new CGL.Uniform(PBRShader, "f", "_ThinFilmIOR", inThinFilmIOR);
+const inThinFilmThicknessUniform = new CGL.Uniform(PBRShader, "f", "_ThinFilmThickness", inThinFilmThickness);
+
 const inPCOrigin = new CGL.Uniform(PBRShader, "3f", "_PCOrigin", [0, 0, 0]);
 const inPCboxMin = new CGL.Uniform(PBRShader, "3f", "_PCboxMin", [-1, -1, -1]);
 const inPCboxMax = new CGL.Uniform(PBRShader, "3f", "_PCboxMax", [1, 1, 1]);
@@ -169,6 +179,7 @@ inTexAORM.onChange =
     inUseOptimizedHeight.onChange =
     inUseVertexColours.onChange =
     inToggleGR.onChange =
+    inUseThinFilm.onChange =
     inVertexColourMode.onChange = updateDefines;
 
 function updateDefines()
@@ -183,6 +194,7 @@ function updateDefines()
     PBRShader.toggleDefine("USE_HEIGHT_TEX", inTexHeight.isLinked());
     PBRShader.toggleDefine("DONT_USE_NMGR", inToggleNMGR.get());
     PBRShader.toggleDefine("DONT_USE_GR", inToggleGR.get());
+    PBRShader.toggleDefine("USE_THIN_FILM", inUseThinFilm.get());
 
     // VERTEX_COLORS
     PBRShader.toggleDefine("VCOL_COLOUR", inVertexColourMode.get() === "colour");
@@ -427,7 +439,7 @@ function doRender()
     if (inTexHeight.get()) PBRShader.pushTexture(inHeightUniform, inTexHeight.get().tex);
     if (inLightmap.get()) PBRShader.pushTexture(inLightmapUniform, inLightmap.get().tex);
     if (inTexClearCoatNormal.get()) PBRShader.pushTexture(inCCNormalUniform, inTexClearCoatNormal.get().tex);
-    
+
     updateLights();
     updateLightUniforms();
 

--- a/src/ops/base/Ops.Gl.Pbr.PbrMaterial/att_BasicPBR.frag
+++ b/src/ops/base/Ops.Gl.Pbr.PbrMaterial/att_BasicPBR.frag
@@ -2,6 +2,10 @@ precision highp float;
 precision highp int;
 {{MODULES_HEAD}}
 
+#ifndef PI
+#define PI 3.14159265358
+#endif
+
 // set by cables
 UNI vec3 camPos;
 // utility maps
@@ -44,6 +48,11 @@ UNI vec3 camPos;
             UNI sampler2D _CCNormalMap;
         #endif
     #endif
+#endif
+#ifdef USE_THIN_FILM
+    UNI float _ThinFilmIntensity;
+    UNI float _ThinFilmIOR;
+    UNI float _ThinFilmThickness;
 #endif
 // IBL inputs
 #ifdef USE_ENVIRONMENT_LIGHTING
@@ -95,6 +104,7 @@ IN vec3 normM;
         IN mat3 invTBN;
     #endif
 #endif
+
 
 // structs
 struct Light {
@@ -232,6 +242,129 @@ vec3 BoxProjection(vec3 direction, vec3 position, vec3 cubemapPosition, vec3 box
 }
 #endif
 
+#ifdef USE_THIN_FILM
+// section from https://github.com/BabylonJS/Babylon.js/blob/8a5077e0efb4ba471d16f7cd010fe6124ea8d005/packages/dev/core/src/Shaders/ShadersInclude/pbrBRDFFunctions.fx
+// helper functions from https://github.com/BabylonJS/Babylon.js/blob/8a5077e0efb4ba471d16f7cd010fe6124ea8d005/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+float square(float value)
+{
+    return value * value;
+}
+vec3 square(vec3 value)
+{
+    return value * value;
+}
+float pow5(float value) {
+    float sq = value * value;
+    return sq * sq * value;
+}
+const mat3 XYZ_TO_REC709 = mat3(
+     3.2404542, -0.9692660,  0.0556434,
+    -1.5371385,  1.8760108, -0.2040259,
+    -0.4985314,  0.0415560,  1.0572252
+);
+// Assume air interface for top
+// Note: We don't handle the case fresnel0 == 1
+vec3 getIORTfromAirToSurfaceR0(vec3 f0) {
+    vec3 sqrtF0 = sqrt(f0);
+    return (1. + sqrtF0) / (1. - sqrtF0);
+}
+
+// Conversion FO/IOR
+vec3 getR0fromIORs(vec3 iorT, float iorI) {
+    return square((iorT - vec3(iorI)) / (iorT + vec3(iorI)));
+}
+
+float getR0fromIORs(float iorT, float iorI) {
+    return square((iorT - iorI) / (iorT + iorI));
+}
+
+// Fresnel equations for dielectric/dielectric interfaces.
+// Ref: https://belcour.github.io/blog/research/publication/2017/05/01/brdf-thin-film.html
+// Evaluation XYZ sensitivity curves in Fourier space
+vec3 evalSensitivity(float opd, vec3 shift) {
+    float phase = 2.0 * PI * opd * 1.0e-9;
+
+    const vec3 val = vec3(5.4856e-13, 4.4201e-13, 5.2481e-13);
+    const vec3 pos = vec3(1.6810e+06, 1.7953e+06, 2.2084e+06);
+    const vec3 var = vec3(4.3278e+09, 9.3046e+09, 6.6121e+09);
+
+    vec3 xyz = val * sqrt(2.0 * PI * var) * cos(pos * phase + shift) * exp(-square(phase) * var);
+    xyz.x += 9.7470e-14 * sqrt(2.0 * PI * 4.5282e+09) * cos(2.2399e+06 * phase + shift[0]) * exp(-4.5282e+09 * square(phase));
+    xyz /= 1.0685e-7;
+
+    vec3 srgb = XYZ_TO_REC709 * xyz;
+    return srgb;
+}
+// from https://github.com/BabylonJS/Babylon.js/blob/8a5077e0efb4ba471d16f7cd010fe6124ea8d005/packages/dev/core/src/Shaders/ShadersInclude/pbrBRDFFunctions.fx
+vec3 fresnelSchlickGGX(float VdotH, vec3 reflectance0, vec3 reflectance90)
+{
+    return reflectance0 + (reflectance90 - reflectance0) * pow5(1.0 - VdotH);
+}
+float fresnelSchlickGGX(float VdotH, float reflectance0, float reflectance90)
+{
+    return reflectance0 + (reflectance90 - reflectance0) * pow5(1.0 - VdotH);
+}
+vec3 evalIridescence(float outsideIOR, float eta2, float cosTheta1, float thinFilmThickness, vec3 baseF0) {
+    vec3 I = vec3(1.0);
+
+    // Force iridescenceIOR -> outsideIOR when thinFilmThickness -> 0.0
+    float iridescenceIOR = mix(outsideIOR, eta2, smoothstep(0.0, 0.03, thinFilmThickness));
+    // Evaluate the cosTheta on the base layer (Snell law)
+    float sinTheta2Sq = square(outsideIOR / iridescenceIOR) * (1.0 - square(cosTheta1));
+
+    // Handle TIR:
+    float cosTheta2Sq = 1.0 - sinTheta2Sq;
+    if (cosTheta2Sq < 0.0) {
+        return I;
+    }
+
+    float cosTheta2 = sqrt(cosTheta2Sq);
+
+    // First interface
+    float R0 = getR0fromIORs(iridescenceIOR, outsideIOR);
+    float R12 = fresnelSchlickGGX(cosTheta1, R0, 1.);
+    float R21 = R12;
+    float T121 = 1.0 - R12;
+    float phi12 = 0.0;
+    if (iridescenceIOR < outsideIOR) phi12 = PI;
+    float phi21 = PI - phi12;
+
+    // Second interface
+    vec3 baseIOR = getIORTfromAirToSurfaceR0(clamp(baseF0, 0.0, 0.9999)); // guard against 1.0
+    vec3 R1 = getR0fromIORs(baseIOR, iridescenceIOR);
+    vec3 R23 = fresnelSchlickGGX(cosTheta2, R1, vec3(1.));
+    vec3 phi23 = vec3(0.0);
+    if (baseIOR[0] < iridescenceIOR) phi23[0] = PI;
+    if (baseIOR[1] < iridescenceIOR) phi23[1] = PI;
+    if (baseIOR[2] < iridescenceIOR) phi23[2] = PI;
+
+    // Phase shift
+    float opd = 2.0 * iridescenceIOR * thinFilmThickness * cosTheta2;
+    vec3 phi = vec3(phi21) + phi23;
+
+    // Compound terms
+    vec3 R123 = clamp(R12 * R23, 1e-5, 0.9999);
+    vec3 r123 = sqrt(R123);
+    vec3 Rs = square(T121) * R23 / (vec3(1.0) - R123);
+
+    // Reflectance term for m = 0 (DC term amplitude)
+    vec3 C0 = R12 + Rs;
+    I = C0;
+
+    // Reflectance term for m > 0 (pairs of diracs)
+    vec3 Cm = Rs - T121;
+    for (int m = 1; m <= 2; ++m)
+    {
+        Cm *= r123;
+        vec3 Sm = 2.0 * evalSensitivity(float(m) * opd, float(m) * phi);
+        I += Cm * Sm;
+    }
+
+    // Since out of gamut colors might be produced, negative color values are clamped to 0.
+    return max(I, vec3(0.0));
+}
+#endif
+
 {{PBR_FRAGMENT_HEAD}}
 void main()
 {
@@ -338,6 +471,13 @@ void main()
     float NdotV          = abs(dot(N, V));
     vec3  F0             = mix(vec3(0.04), AlbedoMap.rgb, metalness);
 
+    #ifdef USE_THIN_FILM
+        float viewAngle = sqrt(1.0 + (square(NdotV) - 1.0));
+        vec3 iridescenceFresnel = evalIridescence(1.0, _ThinFilmIOR, viewAngle, _ThinFilmThickness, F0);
+
+        F0 = mix(F0, iridescenceFresnel, _ThinFilmIntensity);
+    #endif
+
     #ifndef WEBGL1
         #ifndef DONT_USE_GR
             // from https://github.com/BabylonJS/Babylon.js/blob/5e6321d887637877d8b28b417410abbbeb651c6e/src/Shaders/ShadersInclude/pbrHelperFunctions.fx
@@ -389,6 +529,7 @@ void main()
             #else
                 vec3 IBLIrradiance = DecodeRGBE8(SAMPLETEX(_irradiance, N, 0.0)) * diffuseIntensity;
         #endif
+
 	    vec3 Fd = (1.0 - metalness) * albedo * IBLIrradiance * (1.0 - E) * AO;
     #endif
     vec3 directLighting = vec3(0.0);

--- a/src/ops/base/Ops.Gl.Pbr.PbrMaterial/att_BasicPBR.frag
+++ b/src/ops/base/Ops.Gl.Pbr.PbrMaterial/att_BasicPBR.frag
@@ -472,8 +472,7 @@ void main()
     vec3  F0             = mix(vec3(0.04), AlbedoMap.rgb, metalness);
 
     #ifdef USE_THIN_FILM
-        float viewAngle = sqrt(1.0 + (square(NdotV) - 1.0));
-        vec3 iridescenceFresnel = evalIridescence(1.0, _ThinFilmIOR, viewAngle, _ThinFilmThickness, F0);
+        vec3 iridescenceFresnel = evalIridescence(1.0, _ThinFilmIOR, NdotV, _ThinFilmThickness, F0);
 
         F0 = mix(F0, iridescenceFresnel, _ThinFilmIntensity);
     #endif

--- a/src/ops/base/Ops.Gl.Pbr.PbrMaterial/att_light_includes.frag
+++ b/src/ops/base/Ops.Gl.Pbr.PbrMaterial/att_light_includes.frag
@@ -1,5 +1,6 @@
-
+#ifndef PI
 #define PI 3.14159265359
+#endif
 
 // from https://github.com/google/filament/blob/036bfa9b20d730bb8e5852ed449b024570167648/shaders/src/brdf.fs
 // modified to fit variable names / structure


### PR DESCRIPTION
Intensity and options to use normal maps for clearcoat, thin film IOR/intensity/thickness with the thin film implementation from babylonjs. also emission texture option.

Examples:
https://dev.cables.gl/p/ONfqHI
https://dev.cables.gl/p/NTmtwI
https://dev.cables.gl/p/IL2MJI