### PR TITLE
Bugfix default behaviour on Ops.Boolean.ToggleBool_v2.js

### DIFF
--- a/src/ops/base/Ops.Boolean.ToggleBool_v2/Ops.Boolean.ToggleBool_v2.js
+++ b/src/ops/base/Ops.Boolean.ToggleBool_v2/Ops.Boolean.ToggleBool_v2.js
@@ -9,6 +9,7 @@ let theBool = false;
 
 op.onLoadedValueSet = () =>
 {
+    theBool = inDefault.get();
     outBool.set(inDefault.get());
     next.trigger();
 };


### PR DESCRIPTION
Bug is that when ToggleBool default is set to TRUE, then on load it takes two triggers to get it to be FALSE. 

To reproduce:
-Go to this patch https://cables.gl/edit/E3h58l
-Select the ToggleBool op 
-Notice that the ToggleBool is default TRUE 
-Press Toggle and notice you have to press it twice for the correct behaviour to start happening
-If you refresh the patch you will get the same bug.

Underlying problem is that the loading callback sets the output to the default but doesn't also set the internal variable (theBool) to the default. 

Demo of the proposed bugfix is also on the patch. 