### PR TITLE
Update Ops.Array.Array_v3.js

### DIFF
--- a/src/ops/base/Ops.Array.Array_v3/Ops.Array.Array_v3.js
+++ b/src/ops/base/Ops.Array.Array_v3/Ops.Array.Array_v3.js
@@ -62,9 +62,15 @@ function reset()
     // mode 2 Normalized array
     else if (selectIndex === MODE_0_TO_1)
     {
-        for (i = 0; i < arrLength; i++)
+        if (arrLength > 1) { 
+            for (i = 0; i < arrLength; i++)
+                {
+                    arr[i] = i / (arrLength - 1);
+                }
+        } else 
         {
-            arr[i] = i / (arrLength - 1);
+            //When array length is only 1 
+            arr = [0];
         }
     }
 


### PR DESCRIPTION
Bugfix when array has only 1 element in 0-1 normalise mode.  Produces [0] instead of [null]

## To replicate bug
1. go to https://cables.gl/edit/ntYPhp
2. Set the count to 1 and the array op to '0-1' normalised mode 
3. notice the output is a single element of null value

The proposed bugfix is also in that cables patch as another op


