### PR TITLE
Update Ops.Gl.ShaderEffects.VertexDisplacementMap_v5.json

### DIFF
--- a/src/ops/base/Ops.Gl.ShaderEffects.VertexDisplacementMap_v5/Ops.Gl.ShaderEffects.VertexDisplacementMap_v5.json
+++ b/src/ops/base/Ops.Gl.ShaderEffects.VertexDisplacementMap_v5/Ops.Gl.ShaderEffects.VertexDisplacementMap_v5.json
@@ -179,8 +179,12 @@
     ],
     "summary": "Displace the vertices of a mesh with the pixels brightness values from a texture",
     "issues": "",
+    "youtubeids": [
+        "a56wk9Xm9dY"
+    ],
     "docs": {
         "ports": []
     },
+    "exampleProjectId": "aSWlLu",
     "license": "MIT"
 }


### PR DESCRIPTION
The example and the video were missing, which are in v4.