### PR TITLE
Update GLTFScene to support proper animation looping in a .glb file with multiple animations

### DIFF
--- a/src/ops/base/Ops.Gl.GLTF.GltfScene_v4/Ops.Gl.GLTF.GltfScene_v4.js
+++ b/src/ops/base/Ops.Gl.GLTF.GltfScene_v4/Ops.Gl.GLTF.GltfScene_v4.js
@@ -52,6 +52,7 @@ let cam = null;
 let boundingPoints = [];
 let gltf = null;
 let maxTime = 0;
+let maxTimeDict = {};
 let time = 0;
 let needsMatUpdate = true;
 let timedLoader = null;
@@ -260,7 +261,6 @@ function finishLoading()
 
     needsMatUpdate = true;
     // op.refreshParams();
-    outAnimLength.set(maxTime);
 
     gltf.bounds = new CABLES.CG.BoundingBox();
     // gltf.bounds.applyPos(0, 0, 0);
@@ -585,6 +585,8 @@ function updateAnimation()
         {
             gltf.nodes[i].setAnimAction(inAnimation.get());
         }
+        maxTime=maxTimeDict[inAnimation.get()];
+        outAnimLength.set(maxTime);
     }
 }
 

--- a/src/ops/base/Ops.Gl.GLTF.GltfScene_v4/Ops.Gl.GLTF.GltfScene_v4.js
+++ b/src/ops/base/Ops.Gl.GLTF.GltfScene_v4/Ops.Gl.GLTF.GltfScene_v4.js
@@ -585,7 +585,7 @@ function updateAnimation()
         {
             gltf.nodes[i].setAnimAction(inAnimation.get());
         }
-        maxTime=maxTimeDict[inAnimation.get()];
+        maxTime=maxTimeDict[inAnimation.get()]  ?? -1;
         outAnimLength.set(maxTime);
     }
 }

--- a/src/ops/base/Ops.Gl.GLTF.GltfScene_v4/att_inc_gltf.js
+++ b/src/ops/base/Ops.Gl.GLTF.GltfScene_v4/att_inc_gltf.js
@@ -125,7 +125,8 @@ function readChunk(dv, bArr, arrayBuffer, offset)
 function loadAnims(gltf)
 {
     const uniqueAnimNames = {};
-
+    maxTimeDict = {};
+    
     for (let i = 0; i < gltf.json.animations.length; i++)
     {
         const an = gltf.json.animations[i];
@@ -184,7 +185,7 @@ function loadAnims(gltf)
 
                 for (let j = 0; j < bufferIn.length; j++)
                 {
-                    maxTime = Math.max(bufferIn[j], maxTime);
+                    maxTimeDict[an.name] = bufferIn[j];
 
                     for (let k = 0; k < numComps; k++)
                     {


### PR DESCRIPTION
Fix for https://github.com/cables-gl/cables_docs/issues/1040 

Internally adds a dictionary that's filled with animation names and their lengths.
When the animation is updated it recalls the appropriate length from that dictionary

Demo here https://dev.cables.gl/edit/L9ebRL

Tested also these cases
* .glb file without animations displays ok (no matter if you have an animation name specified or not)
* supplying animated .glb with wrong or blank animation name will leave the model onscreen doing the last valid animation, possibly with the wrong loop point. This was the existing behavior for incorrect animation names so I left it as is.