### PR TITLE
bug: ScaleTexture_v2 op should initialize shader CLEAR define

### DIFF
--- a/src/ops/base/Ops.Gl.ImageCompose.ScaleTexture_v2/Ops.Gl.ImageCompose.ScaleTexture_v2.js
+++ b/src/ops/base/Ops.Gl.ImageCompose.ScaleTexture_v2/Ops.Gl.ImageCompose.ScaleTexture_v2.js
@@ -16,6 +16,7 @@ const cgl = op.patch.cgl;
 const shader = new CGL.Shader(cgl, op.name, op);
 
 shader.setSource(shader.getDefaultVertexShader(), attachments.scale_frag);
+shader.toggleDefine("CLEAR", inClear.get());
 
 const
     textureUniform = new CGL.Uniform(shader, "t", "tex", 0),


### PR DESCRIPTION
ScaleTexture_v2 is only setting the CLEAR shader define onChange, so the op's default Clear value of true has no effect.

repro patch: https://cables.gl/p/kRdVUY

expected behavior: original texture should be cleared. 
observed behavior: original texture remains until the Clear bit is flipped off and back on