### PR TITLE
docs: add links to perf faq and profiler to perf measure op doc

### DIFF
--- a/src/ops/base/Ops.Gl.PerformanceMeasure/Ops.Gl.PerformanceMeasure.md
+++ b/src/ops/base/Ops.Gl.PerformanceMeasure/Ops.Gl.PerformanceMeasure.md
@@ -1,0 +1,3 @@
+For a CPU profile of your entire patch, you can find the patch profiler under Tools > Profile.
+
+For more information about performance optimization, see the "Tools for debugging your patch" section of the cables documentation: https://cables.gl/docs/9_performance_optimization/01_tools/tools


### PR DESCRIPTION
Adding references to the existing profiling/debugging documentation to the performance measure op documentation. I managed to entirely miss that the profiler existed, so just making another path to the existing resources. 