### PR TITLE
Manual 16xMSAA for PixelDisplacement

### DIFF
--- a/src/ops/base/Ops.Gl.ImageCompose.PixelDisplacement_v4/Ops.Gl.ImageCompose.PixelDisplacement_v4.js
+++ b/src/ops/base/Ops.Gl.ImageCompose.PixelDisplacement_v4/Ops.Gl.ImageCompose.PixelDisplacement_v4.js
@@ -9,6 +9,7 @@ const
     inInput = op.inValueSelect("Input", ["Luminance", "RedGreen", "Red", "Green", "Blue"], "Luminance"),
     inZero = op.inSwitch("Zero Displace", ["Grey", "Black"], "Grey"),
     inMapping = op.inSwitch("Pixel Mapping", ["Stretch", "Repeat"], "Stretch"),
+    inMultisample = op.inValueBool("MSAA", false),
     trigger = op.outTrigger("trigger");
 
 op.setPortGroup("Axis Displacement Strength", [amountX, amountY]);
@@ -27,11 +28,13 @@ const
     amountXUniform = new CGL.Uniform(shader, "f", "amountX", amountX),
     amountYUniform = new CGL.Uniform(shader, "f", "amountY", amountY),
     repeatUni = new CGL.Uniform(shader, "2f", "repeat", 1, 1),
-    amountUniform = new CGL.Uniform(shader, "f", "amount", amount);
+    amountUniform = new CGL.Uniform(shader, "f", "amount", amount),
+    uniPSize = new CGL.Uniform(shader, "2f", "psize", 0,0);
 
 inMapping.onChange =
 inZero.onChange =
 inWrap.onChange =
+inMultisample.onChange =
 inInput.onChange = updateDefines;
 
 updateDefines();
@@ -55,6 +58,8 @@ function updateDefines()
     shader.removeDefine("INPUT_REDGREEN");
     shader.removeDefine("INPUT_RED");
     shader.define("INPUT_" + (inInput.get() + "").toUpperCase());
+
+    shader.toggleDefine("USE_MSAA", inMultisample.get());
 }
 
 render.onTriggered = function ()
@@ -65,13 +70,17 @@ render.onTriggered = function ()
     {
         cgl.pushShader(shader);
         cgl.currentTextureEffect.bind();
-
+        
+        let w = cgl.currentTextureEffect.getCurrentSourceTexture().width;
+        let h = cgl.currentTextureEffect.getCurrentSourceTexture().height;
+        
         repeatUni.setValue([
-            cgl.currentTextureEffect.getCurrentSourceTexture().width / displaceTex.get().width,
-            cgl.currentTextureEffect.getCurrentSourceTexture().height / displaceTex.get().height]);
+            w / displaceTex.get().width,
+            h / displaceTex.get().height]);
 
         cgl.setTexture(0, cgl.currentTextureEffect.getCurrentSourceTexture().tex);
         if (displaceTex.get()) cgl.setTexture(1, displaceTex.get().tex);
+        if (inMultisample.get()) uniPSize.setValue([(1.0/w)*(1.0/16.0),(1.0/h)*(1.0/16.0)]);
 
         cgl.currentTextureEffect.finish();
         cgl.popShader();

--- a/src/ops/base/Ops.Gl.ImageCompose.PixelDisplacement_v4/att_pixeldisplace3.frag
+++ b/src/ops/base/Ops.Gl.ImageCompose.PixelDisplacement_v4/att_pixeldisplace3.frag
@@ -1,10 +1,10 @@
 IN vec2 texCoord;
 UNI sampler2D tex;
 UNI sampler2D displaceTex;
+UNI vec2 psize;
 UNI float amountX;
 UNI float amountY;
 UNI float amount;
-
 #ifdef MAPPING_REPEAT
     UNI vec2 repeat;
 #endif
@@ -33,7 +33,7 @@ float getOffset(float offset)
     #endif
 }
 
-void main()
+vec2 getMapping(vec2 texCoord)
 {
     #ifndef MAPPING_REPEAT
         vec4 rgba=texture(displaceTex,texCoord);
@@ -86,9 +86,46 @@ void main()
         y=abs((floor(my)-fract(my)));
     #endif
 
+    return vec2(x,y);
+}
 
+#ifdef USE_MSAA
+const vec2 S16[16] = vec2[](
+    vec2( 1.0,  1.0),
+    vec2(-1.0, -3.0),
+    vec2(-3.0,  2.0),
+    vec2( 4.0, -1.0),
+    vec2(-5.0, -2.0),
+    vec2( 2.0,  5.0),
+    vec2( 5.0,  3.0),
+    vec2( 3.0, -5.0),
+    vec2(-2.0,  6.0),
+    vec2( 0.0, -7.0),
+    vec2(-4.0, -6.0),
+    vec2(-6.0,  4.0),
+    vec2(-8.0,  0.0),
+    vec2( 7.0, -4.0),
+    vec2( 6.0,  7.0),
+    vec2(-7.0, -8.0)
+);
+#endif
 
-    vec4 col=texture(tex,vec2(x,y));
+void main()
+{
+    #ifndef USE_MSAA
+    vec2 texCoordDisplaced = getMapping(texCoord);
+
+    vec4 col=texture(tex,texCoordDisplaced);
+    #else
+    vec4 col = vec4(0.0);
+
+    for (int i = 0; i < S16.length(); ++i) {
+        vec2 s = getMapping(texCoord + S16[i] * psize);
+        col += texture(tex,s);
+    }
+    col = col / float(S16.length());
+    #endif
+
     vec4 base=texture(tex,texCoord);
 
     base.a=0.0;


### PR DESCRIPTION
Brute force 16xMSAA to get rid of aliasing in very strong PixelDisplacements. Example: [https://dev.cables.gl/p/1iOTJi](https://dev.cables.gl/p/1iOTJi)
Could maybe be changed to include 2/4/8/16 toggles and proper distance math in the future.