### PR TITLE
Adding DesktopAudio capture op for electron

### DIFF
--- a/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.js
+++ b/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.js
@@ -14,7 +14,6 @@ let stream = null;
 let audioCtx = null;
 let mediaStreamSource = null;
 let gainNode = null;
-let permissionCheckInterval = null;
 
 op.onDelete = cleanup;
 
@@ -38,37 +37,44 @@ inVolume.onChange = () =>
     }
 };
 
-// Periodic check of macOS permission status
 const isMac = (typeof process !== "undefined" && process.platform === "darwin") || 
               (typeof navigator !== "undefined" && /Mac/i.test(navigator.platform || navigator.userAgent));
 const isWindows = (typeof process !== "undefined" && process.platform === "win32") || 
                   (typeof navigator !== "undefined" && /Win/i.test(navigator.platform || navigator.userAgent));
 
-if (isMac)
-{
-    permissionCheckInterval = setInterval(checkPermissionStatus, 5000);
-}
-
 // Initial check
 checkPermissionStatus();
 
-function checkPermissionStatus()
+function getIpcRenderer()
 {
-    let ipc = window.ipcRenderer;
-    if (!ipc)
-    {
-        const electron = op.require("electron");
-        if (electron) ipc = electron.ipcRenderer;
-    }
+    if (window.ipcRenderer) return window.ipcRenderer;
 
-    if (!ipc && window.nodeRequire)
+    if (typeof op.require === "function")
     {
         try
         {
-            ipc = window.nodeRequire("electron").ipcRenderer;
+            const electron = op.require("electron");
+            if (electron && electron.ipcRenderer) return electron.ipcRenderer;
         }
         catch (e) {}
     }
+
+    if (window.nodeRequire)
+    {
+        try
+        {
+            const electron = window.nodeRequire("electron");
+            if (electron && electron.ipcRenderer) return electron.ipcRenderer;
+        }
+        catch (e) {}
+    }
+
+    return null;
+}
+
+function checkPermissionStatus()
+{
+    const ipc = getIpcRenderer();
 
     if (ipc)
     {
@@ -116,6 +122,7 @@ function cleanup()
 
 function startCapture()
 {
+    checkPermissionStatus();
     cleanup();
 
     const handleStream = (s) =>
@@ -134,7 +141,7 @@ function startCapture()
         const audioTracks = stream.getAudioTracks();
         if (audioTracks.length > 0)
         {
-            if (typeof CABLES !== "undefined" && CABLES.WEBAUDIO)
+            if (CABLES.WEBAUDIO)
             {
                 audioCtx = CABLES.WEBAUDIO.createAudioContext(op);
             }
@@ -196,16 +203,7 @@ function startCapture()
     else
     {
         // Fallback for Windows/Linux desktop capture
-        let ipc = window.ipcRenderer;
-        if (!ipc)
-        {
-            const electron = op.require("electron");
-            if (electron) ipc = electron.ipcRenderer;
-        }
-        if (!ipc && window.nodeRequire)
-        {
-            try { ipc = window.nodeRequire("electron").ipcRenderer; } catch (e) {}
-        }
+        const ipc = getIpcRenderer();
 
         const proceedWithSourceId = (sourceId) =>
         {
@@ -243,16 +241,6 @@ function startCapture()
                     proceedWithSourceId(primary.id);
                 })
                 .catch(handleError);
-        }
-        else if (op.patch.api)
-        {
-            op.patch.api.send("getDesktopCaptureSources", { "types": ["screen"] }, (err, sources) =>
-            {
-                if (err) return handleError(err);
-                const s = sources.success && sources.data ? sources.data : sources;
-                const primary = s[0] || { "id": "screen:0:0" };
-                proceedWithSourceId(primary.id);
-            });
         }
         else
         {

--- a/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.js
+++ b/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.js
@@ -1,0 +1,262 @@
+const
+    inStart = op.inTriggerButton("Start Capture"),
+    inStop = op.inTriggerButton("Stop Capture"),
+    inVolume = op.inValueFloat("Volume", 1.0),
+
+    outAudioNode = op.outObject("Audio Node"),
+    outPermission = op.outString("Permission Status"),
+    outError = op.outString("Error");
+
+op.setPortGroup("Controls", [inStart, inStop]);
+op.setPortGroup("Settings", [inVolume]);
+
+let stream = null;
+let audioCtx = null;
+let mediaStreamSource = null;
+let gainNode = null;
+let permissionCheckInterval = null;
+
+op.onDelete = cleanup;
+
+inStart.onTriggered = () =>
+{
+    op.log("[DesktopAudio] Start Capture triggered");
+    startCapture();
+};
+
+inStop.onTriggered = () =>
+{
+    op.log("[DesktopAudio] Stop Capture triggered");
+    cleanup();
+};
+
+inVolume.onChange = () =>
+{
+    if (gainNode && gainNode.gain)
+    {
+        gainNode.gain.value = inVolume.get();
+    }
+};
+
+// Periodic check of macOS permission status
+const isMac = (typeof process !== "undefined" && process.platform === "darwin") || 
+              (typeof navigator !== "undefined" && /Mac/i.test(navigator.platform || navigator.userAgent));
+const isWindows = (typeof process !== "undefined" && process.platform === "win32") || 
+                  (typeof navigator !== "undefined" && /Win/i.test(navigator.platform || navigator.userAgent));
+
+if (isMac)
+{
+    permissionCheckInterval = setInterval(checkPermissionStatus, 5000);
+}
+
+// Initial check
+checkPermissionStatus();
+
+function checkPermissionStatus()
+{
+    let ipc = window.ipcRenderer;
+    if (!ipc)
+    {
+        const electron = op.require("electron");
+        if (electron) ipc = electron.ipcRenderer;
+    }
+
+    if (!ipc && window.nodeRequire)
+    {
+        try
+        {
+            ipc = window.nodeRequire("electron").ipcRenderer;
+        }
+        catch (e) {}
+    }
+
+    if (ipc)
+    {
+        ipc.invoke("talkerMessage", "getMediaAccessStatus", { "mediaType": "screen" })
+            .then((res) =>
+            {
+                const status = res.data || res;
+                outPermission.set(status);
+            })
+            .catch(() =>
+            {
+                outPermission.set("unknown");
+            });
+    }
+    else
+    {
+        outPermission.set("not-electron");
+    }
+}
+
+function cleanup()
+{
+    outAudioNode.set(null);
+    outError.set("");
+
+    if (stream)
+    {
+        const tracks = stream.getTracks();
+        tracks.forEach((track) => { return track.stop(); });
+        stream = null;
+    }
+
+    if (mediaStreamSource)
+    {
+        try { mediaStreamSource.disconnect(); } catch (e) {}
+        mediaStreamSource = null;
+    }
+
+    if (gainNode)
+    {
+        try { gainNode.disconnect(); } catch (e) {}
+        gainNode = null;
+    }
+}
+
+function startCapture()
+{
+    cleanup();
+
+    const handleStream = (s) =>
+    {
+        op.log("[DesktopAudio] Stream successfully resolved!");
+        stream = s;
+        outError.set("");
+
+        // Stop the video track immediately to save performance/decoding overhead
+        const videoTracks = stream.getVideoTracks();
+        if (videoTracks.length > 0)
+        {
+            videoTracks[0].stop();
+        }
+
+        const audioTracks = stream.getAudioTracks();
+        if (audioTracks.length > 0)
+        {
+            if (typeof CABLES !== "undefined" && CABLES.WEBAUDIO)
+            {
+                audioCtx = CABLES.WEBAUDIO.createAudioContext(op);
+            }
+            else
+            {
+                window.AudioContext = window.AudioContext || window.webkitAudioContext;
+                if (window.AudioContext)
+                {
+                    if (!window.audioContext) window.audioContext = new AudioContext();
+                    audioCtx = window.audioContext;
+                }
+            }
+            if (audioCtx)
+            {
+                if (audioCtx.state === "suspended")
+                {
+                    audioCtx.resume()
+                        .catch((re) => { op.error("[DesktopAudio] Failed to resume AudioContext:", re); });
+                }
+
+                mediaStreamSource = audioCtx.createMediaStreamSource(stream);
+                gainNode = audioCtx.createGain();
+                gainNode.gain.value = inVolume.get();
+                
+                mediaStreamSource.connect(gainNode);
+                outAudioNode.set(gainNode);
+                op.log("[DesktopAudio] Successfully connected loopback audio stream.");
+            }
+            else
+            {
+                outError.set("AudioContext not available");
+            }
+        }
+        else
+        {
+            outError.set("No audio tracks found in stream");
+        }
+    };
+
+    const handleError = (e) =>
+    {
+        op.error("[DesktopAudio] Get Media Error:", e);
+        outError.set("Capture Error: " + e.message);
+    };
+
+    if (isMac || isWindows)
+    {
+        op.log(`[DesktopAudio] ${isMac ? "macOS" : "Windows"} loopback requested, calling getDisplayMedia...`);
+        navigator.mediaDevices.getDisplayMedia({
+            "video": {
+                "width": 1,
+                "height": 1
+            },
+            "audio": true
+        })
+        .then(handleStream)
+        .catch(handleError);
+    }
+    else
+    {
+        // Fallback for Windows/Linux desktop capture
+        let ipc = window.ipcRenderer;
+        if (!ipc)
+        {
+            const electron = op.require("electron");
+            if (electron) ipc = electron.ipcRenderer;
+        }
+        if (!ipc && window.nodeRequire)
+        {
+            try { ipc = window.nodeRequire("electron").ipcRenderer; } catch (e) {}
+        }
+
+        const proceedWithSourceId = (sourceId) =>
+        {
+            const constraints = {
+                "audio": {
+                    "mandatory": {
+                        "chromeMediaSource": "desktop",
+                        "chromeMediaSourceId": sourceId
+                    }
+                },
+                "video": {
+                    "mandatory": {
+                        "chromeMediaSource": "desktop",
+                        "chromeMediaSourceId": sourceId,
+                        "minWidth": 1,
+                        "maxWidth": 1,
+                        "minHeight": 1,
+                        "maxHeight": 1
+                    }
+                }
+            };
+            op.log("[DesktopAudio] Non-macOS requested, calling getUserMedia...");
+            navigator.mediaDevices.getUserMedia(constraints)
+                .then(handleStream)
+                .catch(handleError);
+        };
+
+        if (ipc)
+        {
+            ipc.invoke("getDesktopCaptureSources", { "types": ["screen"] })
+                .then((sources) =>
+                {
+                    const s = sources.success && sources.data ? sources.data : sources;
+                    const primary = s[0] || { "id": "screen:0:0" };
+                    proceedWithSourceId(primary.id);
+                })
+                .catch(handleError);
+        }
+        else if (op.patch.api)
+        {
+            op.patch.api.send("getDesktopCaptureSources", { "types": ["screen"] }, (err, sources) =>
+            {
+                if (err) return handleError(err);
+                const s = sources.success && sources.data ? sources.data : sources;
+                const primary = s[0] || { "id": "screen:0:0" };
+                proceedWithSourceId(primary.id);
+            });
+        }
+        else
+        {
+            handleError(new Error("Electron IPC not available"));
+        }
+    }
+}

--- a/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.js
+++ b/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.js
@@ -45,31 +45,9 @@ const isWindows = (typeof process !== "undefined" && process.platform === "win32
 // Initial check
 checkPermissionStatus();
 
-function getIpcRenderer()
-{
-    if (window.ipcRenderer) return window.ipcRenderer;
-
-    if (typeof op.require === "function")
-    {
-        try
-        {
-            const electron = op.require("electron");
-            if (electron && electron.ipcRenderer) return electron.ipcRenderer;
-        }
-        catch (e) {}
-    }
-
-    if (window.nodeRequire)
-    {
-        try
-        {
-            const electron = window.nodeRequire("electron");
-            if (electron && electron.ipcRenderer) return electron.ipcRenderer;
-        }
-        catch (e) {}
-    }
-
-    return null;
+function getIpcRenderer() {
+    const electron = op.require("electron");
+    if (!electron || !electron.ipcRenderer) electron.ipcRenderer.send("closeApplication");
 }
 
 function checkPermissionStatus()

--- a/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.json
+++ b/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.json
@@ -1,0 +1,111 @@
+{
+    "id": "e2a3c4b5-6a7b-8c9d-0e1f-2a3b4c5d6e7f",
+    "authorName": "Uuoocl",
+    "created": 1736418000000,
+    "layout": {
+        "portsIn": [
+            {
+                "type": 0,
+                "name": "Active",
+                "group": "Audio Settings",
+                "subType": "boolean"
+            },
+            {
+                "type": 1,
+                "name": "Refresh Sources",
+                "group": "Source Settings"
+            },
+            {
+                "type": 0,
+                "name": "Source index",
+                "group": "Source Settings",
+                "subType": "integer"
+            },
+            {
+                "type": 0,
+                "name": "Volume",
+                "group": "Audio Settings",
+                "subType": "number"
+            }
+        ],
+        "portsOut": [
+            {
+                "type": 2,
+                "name": "Audio Node"
+            },
+            {
+                "type": 2,
+                "name": "MediaStream"
+            },
+            {
+                "type": 0,
+                "name": "Has Audio Track",
+                "subType": "boolean"
+            },
+            {
+                "type": 5,
+                "name": "Permission Status"
+            },
+            {
+                "type": 5,
+                "name": "Error"
+            }
+        ]
+    },
+    "summary": "Capture desktop window or system audio stream using Electron's desktopCapturer",
+    "docs": {
+        "ports": [
+            {
+                "name": "Active",
+                "text": "Toggles capturing active state."
+            },
+            {
+                "name": "Refresh Sources",
+                "text": "Query and populate the list of windows and screens."
+            },
+            {
+                "name": "Source",
+                "text": "Dropdown to select which window or screen's audio is captured."
+            },
+            {
+                "name": "Volume",
+                "text": "Gain multiplier applied to the output Audio Node."
+            },
+            {
+                "name": "Audio Node",
+                "text": "The Web Audio API GainNode outputting the captured stereo audio stream."
+            },
+            {
+                "name": "MediaStream",
+                "text": "Exposes the raw media stream object containing the tracks."
+            },
+            {
+                "name": "Has Audio Track",
+                "text": "True if an audio track is successfully captured and active."
+            },
+            {
+                "name": "Permission Status",
+                "text": "macOS screen recording privacy permission status."
+            },
+            {
+                "name": "Error",
+                "text": "Error diagnostics if capture fails."
+            }
+        ]
+    },
+    "coreLibs": [
+        "cgl",
+        "standalone_electron",
+        "webaudio"
+    ],
+    "changelog": [
+        {
+            "message": "op created",
+            "type": "new op",
+            "author": "Uuoocl",
+            "date": 1771498594000
+        }
+    ],
+    "license": "MIT",
+    "isReleased": true
+}

--- a/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.md
+++ b/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.DesktopAudio/Ops.Extension.Standalone.DesktopAudio.md
@@ -1,0 +1,10 @@
+# Ops.Extension.Standalone.DesktopAudio
+
+This op captures system audio streams natively in the Cables Electron standalone player using `desktopCapturer` APIs.
+
+## How to Use:
+1. Trigger start input.
+3. Patch the **Audio Node** output to standard audio visualizers (like `FreqAnalyzer`) or gain controls to hear and visualize the desktop audio!
+
+> [!NOTE]
+> On macOS, make sure that **Screen Recording** permissions are enabled in your System Preferences. The **Permission Status** output will display the active permission state.


### PR DESCRIPTION
The electron desktopCapturer module supports system audio capture. The DesktopAudio op captures system audio and outputs an audio node.   