### PR TITLE
fix: the ffmpeg extension passes user-controlled inp... in...

### DIFF
--- a/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.Ffmpeg/Ops.Extension.Standalone.Ffmpeg.js
+++ b/src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.Ffmpeg/Ops.Extension.Standalone.Ffmpeg.js
@@ -59,11 +59,13 @@ if (ffmpeg)
     {
         op.setUiError("exc", null);
 
-        outBusy.set(true);
-        let fn = inFile.get();
-        fn = fn.replaceAll("%20", " ");
+        const srcFile = inFile.get().replaceAll("%20", " ");
+        if (/[;&|`$<>"\n\r]/.test(srcFile) || /[;&|`$<>"\n\r]/.test(inOutFile.get())) { op.setUiError("exc", "Invalid file path"); return; }
+        if (inTime.get() && (!/^[\d:.]+$/.test(inTimeStart.get()) || !/^[\d:.]+$/.test(inTimeDur.get()))) { op.setUiError("exc", "Invalid time value"); return; }
 
-        loadingId = op.patch.loading.start(op.objName, fn, op);
+        outBusy.set(true);
+
+        loadingId = op.patch.loading.start(op.objName, srcFile, op);
 
         try
         {
@@ -82,7 +84,7 @@ if (ffmpeg)
                 loadingId = op.patch.loading.finished(loadingId);
             });
 
-            ff.input(inFile.get());
+            ff.input(srcFile);
 
             if (inBitrate.get())
                 ff.videoBitrate(inBitrateStr.get(), inBitrateConst.get() == 1);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.Ffmpeg/Ops.Extension.Standalone.Ffmpeg.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.Ffmpeg/Ops.Extension.Standalone.Ffmpeg.js:85` |
| **Assessment** | Likely exploitable |

**Description**: The Ffmpeg extension passes user-controlled input directly to the fluent-ffmpeg library without validation or sanitization. The `inFile.get()` returns a file path from user input, and `inTimeStart.get()` returns a time string. If the fluent-ffmpeg library constructs shell commands internally, an attacker can inject shell metacharacters to execute arbitrary commands.

## Evidence

**Exploitation scenario**: An attacker provides a malicious file path to the 'Source Video' input port, such as: `video.mp4; rm -rf /tmp/*; echo`.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/ops/extensions/Ops.Extension.Standalone/Ops.Extension.Standalone.Ffmpeg/Ops.Extension.Standalone.Ffmpeg.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
